### PR TITLE
Use stored locations to identify chunk loader blocks

### DIFF
--- a/src/main/java/bout2p1_ograines/chunksloader/ChunksLoaderPlugin.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/ChunksLoaderPlugin.java
@@ -251,7 +251,6 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
             return;
         }
 
-        manager.markBlockAsLoader(event.getBlockPlaced());
         manager.addLoader(event.getBlockPlaced().getLocation());
         event.getPlayer().sendMessage(ChatColor.GREEN + "Chunk loader activé.");
     }
@@ -264,7 +263,6 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
         }
 
         event.setDropItems(false);
-        manager.unmarkBlock(block);
         if (manager.removeLoader(block)) {
             block.getWorld().dropItemNaturally(block.getLocation(), createChunkLoaderItem());
             event.getPlayer().sendMessage(ChatColor.YELLOW + "Chunk loader désactivé.");


### PR DESCRIPTION
## Summary
- replace the persistent data based chunk loader detection with location lookups against the saved loader set
- drop now-unnecessary block marking/unmarking calls when placing or breaking loader blocks

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e4e55cf5b0832181ccf01aecb592de