### PR TITLE
Handle invalid chunk loader entries while loading data

### DIFF
--- a/src/main/java/bout2p1_ograines/chunksloader/ChunkLoaderManager.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/ChunkLoaderManager.java
@@ -52,7 +52,14 @@ public class ChunkLoaderManager {
 
         FileConfiguration configuration = YamlConfiguration.loadConfiguration(storageFile);
         for (String worldId : configuration.getKeys(false)) {
-            UUID uuid = UUID.fromString(worldId);
+            UUID uuid;
+            try {
+                uuid = UUID.fromString(worldId);
+            } catch (IllegalArgumentException exception) {
+                plugin.getLogger().warning("Ignoring invalid world identifier '" + worldId + "' in " + STORAGE_FILE);
+                continue;
+            }
+
             List<?> list = configuration.getList(worldId);
             if (list == null) {
                 continue;
@@ -65,6 +72,8 @@ public class ChunkLoaderManager {
                     Integer z = mapValue(map, "z");
                     if (x != null && y != null && z != null) {
                         set.add(new ChunkLoaderLocation(uuid, x, y, z));
+                    } else {
+                        plugin.getLogger().warning("Ignoring invalid chunk loader entry for world '" + worldId + "' in " + STORAGE_FILE);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- skip invalid world identifiers while loading saved chunk loader locations
- log warnings for malformed chunk loader entries instead of failing the load

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e4e6e1fc6083219443e8847e50deeb