### PR TITLE
Switch to Bukkit API for broader compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>jar</packaging>
 
     <name>ChunksLoader</name>
-    <description>Chunk loader plugin for Paper 1.21.9</description>
+    <description>Chunk loader plugin for Bukkit/Spigot 1.20</description>
 
     <properties>
         <java.version>17</java.version>
@@ -19,8 +19,8 @@
 
     <repositories>
         <repository>
-            <id>papermc-repo</id>
-            <url>https://repo.papermc.io/repository/maven-public/</url>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>bluecolored-repo</id>
@@ -30,9 +30,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.papermc.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 main: bout2p1_ograines.chunksloader.ChunksLoaderPlugin
 description: Chunk loader plugin
 author: bout2p1_ograines
-api-version: '1.21'
+api-version: '1.20'
 commands:
   chunksloader:
     description: Gestion des chunk loaders


### PR DESCRIPTION
## Summary
- replace the Paper API dependency with Spigot's Bukkit API to target Java 17 servers
- update the plugin metadata to declare compatibility with the Bukkit/Spigot 1.20 API

## Testing
- mvn -B -ntp package

------
https://chatgpt.com/codex/tasks/task_e_68e4eaa1f0848321815e7a468332687e