### PR TITLE
Update Maven build to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <description>Chunk loader plugin for Bukkit/Spigot 1.20</description>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>


### PR DESCRIPTION
## Summary
- update the project java version to 21 so the BlueMap API dependency compiles

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e4ebeed2c48321988e4afabeec84ff