### PR TITLE
Fix Maven build by targeting Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <description>Chunk loader plugin for Bukkit/Spigot 1.20</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>


### PR DESCRIPTION
## Summary
- update the Maven java.version property to 17 so the compiler plugin uses a supported release on the build agents

## Testing
- mvn -B -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e4ed419e88832195521a002bda4cfc