### PR TITLE
Build jars per Minecraft version up to 1.21.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+assets/*.jar

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # ChunksLoader
+
+This project contains a Bukkit/Spigot chunk loader plugin targeting Minecraft
+releases up to **1.21.9**. The build is parametrised so you can generate jars
+for every compatible version and ship them as release assets.
+
+## Building
+
+```sh
+mvn -DskipTests package
+```
+
+The command above generates a shaded jar named using the pattern
+`ChunksLoader-<minecraft-version>-v<plugin-version>.jar` and places it in both
+`target/` and the repository-level `assets/` directory. By default the Minecraft
+version is set to **1.21.9**.
+
+To produce jars for every supported Minecraft version in one go, use the helper
+script:
+
+```sh
+./scripts/build-all-assets.sh
+```
+
+## Configuration
+
+The plugin ships with a `config.yml` that lets you change the loader radius and
+other behaviour. Adjust the settings to fit your server's needs before
+redeploying the plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,14 @@
     <packaging>jar</packaging>
 
     <name>ChunksLoader</name>
-    <description>Chunk loader plugin for Bukkit/Spigot 1.20</description>
+    <description>Chunk loader plugin for Bukkit/Spigot through Minecraft 1.21.9</description>
 
     <properties>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <mc.version>1.21.9</mc.version>
+        <spigot.api.version>1.21.1-R0.1-SNAPSHOT</spigot.api.version>
     </properties>
 
     <repositories>
@@ -28,7 +30,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <version>${spigot.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -40,6 +42,7 @@
     </dependencies>
 
     <build>
+        <finalName>ChunksLoader-${mc.version}-v${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -59,6 +62,28 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-jar-to-assets</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.basedir}/assets"/>
+                                <copy file="${project.build.directory}/${project.build.finalName}.jar"
+                                      tofile="${project.basedir}/assets/${project.build.finalName}.jar"
+                                      overwrite="true"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/scripts/build-all-assets.sh
+++ b/scripts/build-all-assets.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the plugin for every supported Minecraft version and copies
+# the resulting jars into the assets directory.
+
+if ! command -v mvn >/dev/null 2>&1; then
+  echo "Maven (mvn) is required to run this script." >&2
+  exit 1
+fi
+
+# Map each Minecraft release to the closest available Spigot API version.
+# Spigot publishes API snapshots per major release series rather than for
+# every patch version, so several Minecraft versions share the same API.
+declare -A SPIGOT_VERSIONS=(
+  ["1.20"]="1.20.6-R0.1-SNAPSHOT"
+  ["1.20.1"]="1.20.6-R0.1-SNAPSHOT"
+  ["1.20.2"]="1.20.6-R0.1-SNAPSHOT"
+  ["1.20.3"]="1.20.6-R0.1-SNAPSHOT"
+  ["1.20.4"]="1.20.6-R0.1-SNAPSHOT"
+  ["1.20.5"]="1.20.6-R0.1-SNAPSHOT"
+  ["1.20.6"]="1.20.6-R0.1-SNAPSHOT"
+  ["1.21"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.1"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.2"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.3"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.4"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.5"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.6"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.7"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.8"]="1.21.1-R0.1-SNAPSHOT"
+  ["1.21.9"]="1.21.1-R0.1-SNAPSHOT"
+)
+
+VERSIONS=(
+  1.20
+  1.20.1
+  1.20.2
+  1.20.3
+  1.20.4
+  1.20.5
+  1.20.6
+  1.21
+  1.21.1
+  1.21.2
+  1.21.3
+  1.21.4
+  1.21.5
+  1.21.6
+  1.21.7
+  1.21.8
+  1.21.9
+)
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ASSETS_DIR="$PROJECT_DIR/assets"
+
+mkdir -p "$ASSETS_DIR"
+
+for version in "${VERSIONS[@]}"; do
+  spigot_version="${SPIGOT_VERSIONS[$version]-}"
+  if [[ -z "$spigot_version" ]]; then
+    echo "No Spigot API mapping configured for Minecraft $version" >&2
+    exit 1
+  fi
+
+  echo "\n=== Building for Minecraft $version using Spigot API $spigot_version ==="
+  mvn -B -DskipTests \
+      -Dmc.version="$version" \
+      -Dspigot.api.version="$spigot_version" \
+      clean package
+
+done
+
+echo "\nAll builds complete. Assets are available in $ASSETS_DIR"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 main: bout2p1_ograines.chunksloader.ChunksLoaderPlugin
 description: Chunk loader plugin
 author: bout2p1_ograines
-api-version: '1.20'
+api-version: '1.21'
 commands:
   chunksloader:
     description: Gestion des chunk loaders


### PR DESCRIPTION
## Summary
- parameterise the build with a `mc.version` property and name shaded jars `ChunksLoader-<mc>-v<plugin>.jar`
- update dependencies and plugin metadata to target Spigot/Paper 1.21.x and copy packaged jars into an `assets` directory
- document the workflow and add a helper script that iterates all supported Minecraft versions to populate release assets

## Testing
- `mvn -q -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68e4f90b5f888321bef65831a9479c78