### PR TITLE
Fix JSON output for workflow matrix

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -27,7 +27,7 @@ jobs:
             exit 1
           fi
 
-          json=$(printf '%s\n' "${versions[@]}" | jq -R . | jq -s '{minecraft_version: .}')
+          json=$(printf '%s\n' "${versions[@]}" | jq -R . | jq -c -s '{minecraft_version: .}')
           echo "matrix=$json" >> "$GITHUB_OUTPUT"
 
           {


### PR DESCRIPTION
## Summary
- ensure the determine-versions step outputs compact JSON for the build matrix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e502c708e4832183faac29897829f2