### PR TITLE
Link plugin.yml version to Maven project version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <finalName>ChunksLoader-${mc.version}-v${project.version}</finalName>
         <plugins>
             <plugin>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ChunksLoader
-version: 1.0.0
+version: ${project.version}
 main: bout2p1_ograines.chunksloader.ChunksLoaderPlugin
 description: Chunk loader plugin
 author: bout2p1_ograines


### PR DESCRIPTION
## Summary
- enable Maven resource filtering so plugin metadata can receive project properties
- update plugin.yml to interpolate the project version and keep releases aligned with tags

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e5075b09b483219b8d5fccd76c7e3f