### PR TITLE
Align asset versions with release tags

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.prepare.outputs.matrix }}
+      release_tag: ${{ steps.release-info.outputs.tag }}
+      release_version: ${{ steps.release-info.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,6 +35,34 @@ jobs:
           {
             echo "### Versions"
             printf '* %s\n' "${versions[@]}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Determine release identifier
+        id: release-info
+        run: |
+          if [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+            tag="${GITHUB_REF#refs/tags/}"
+          elif [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+            tag="$GITHUB_REF_NAME"
+          else
+            tag="auto-v${GITHUB_RUN_NUMBER}"
+          fi
+
+          if [[ -z "$tag" ]]; then
+            echo "Unable to determine release tag" >&2
+            exit 1
+          fi
+
+          version="${tag#v}"
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Release"
+            echo
+            echo "- Tag: $tag"
+            echo "- Version: $version"
           } >> "$GITHUB_STEP_SUMMARY"
 
   build:
@@ -68,17 +98,21 @@ jobs:
           mvn -B -DskipTests \
             -Dmc.version="${{ matrix.minecraft_version }}" \
             -Dspigot.api.version="${{ steps.spigot.outputs.spigot }}" \
+            -Drevision="${{ needs.determine-versions.outputs.release_version }}" \
+            -Drelease.tag="${{ needs.determine-versions.outputs.release_tag }}" \
             clean package
 
       - name: Upload asset
         uses: actions/upload-artifact@v4
         with:
           name: chunksloader-${{ matrix.minecraft_version }}
-          path: assets/ChunksLoader-${{ matrix.minecraft_version }}-v*.jar
+          path: assets/ChunksLoader-${{ matrix.minecraft_version }}-${{ needs.determine-versions.outputs.release_tag }}.jar
           if-no-files-found: error
 
   release:
-    needs: build
+    needs:
+      - determine-versions
+      - build
     runs-on: ubuntu-latest
     outputs:
       assets: ${{ steps.collect.outputs.assets }}
@@ -113,8 +147,8 @@ jobs:
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: auto-v${{ github.run_number }}
-          name: Auto Release #${{ github.run_number }}
+          tag_name: ${{ needs.determine-versions.outputs.release_tag }}
+          name: Release ${{ needs.determine-versions.outputs.release_tag }}
           body: |
             Automated release created from commit ${{ github.sha }}.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,20 @@
 
     <groupId>bout2p1_ograines</groupId>
     <artifactId>chunksloader</artifactId>
-    <version>1.0.0</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <name>ChunksLoader</name>
     <description>Chunk loader plugin for Bukkit/Spigot through Minecraft 1.21.9</description>
 
     <properties>
+        <revision>1.0.0</revision>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <mc.version>1.21.9</mc.version>
         <spigot.api.version>1.21.1-R0.1-SNAPSHOT</spigot.api.version>
+        <release.tag>v${revision}</release.tag>
     </properties>
 
     <repositories>
@@ -42,7 +44,13 @@
     </dependencies>
 
     <build>
-        <finalName>ChunksLoader-${mc.version}-v${project.version}</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <finalName>ChunksLoader-${mc.version}-${release.tag}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/scripts/build-all-assets.sh
+++ b/scripts/build-all-assets.sh
@@ -35,10 +35,31 @@ fi
 mkdir -p "$ASSETS_DIR"
 rm -f "$ASSETS_DIR"/ChunksLoader-*.jar
 
-PLUGIN_VERSION=$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version)
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+  raw_tag="$GITHUB_REF_NAME"
+elif [[ "${GITHUB_REF:-}" == refs/tags/* ]]; then
+  raw_tag="${GITHUB_REF#refs/tags/}"
+elif [[ -n "${CI_COMMIT_TAG:-}" ]]; then
+  raw_tag="$CI_COMMIT_TAG"
+elif git -C "$PROJECT_DIR" describe --tags --exact-match >/dev/null 2>&1; then
+  raw_tag="$(git -C "$PROJECT_DIR" describe --tags --exact-match)"
+elif git -C "$PROJECT_DIR" tag --points-at HEAD >/dev/null 2>&1 && \
+     [[ -n "$(git -C "$PROJECT_DIR" tag --points-at HEAD)" ]]; then
+  raw_tag="$(git -C "$PROJECT_DIR" tag --points-at HEAD | head -n1)"
+elif git -C "$PROJECT_DIR" describe --tags --abbrev=0 >/dev/null 2>&1; then
+  raw_tag="$(git -C "$PROJECT_DIR" describe --tags --abbrev=0)"
+fi
 
-if [[ -z "$PLUGIN_VERSION" ]]; then
-  echo "Unable to resolve plugin version from Maven project" >&2
+if [[ -n "${raw_tag:-}" ]]; then
+  RELEASE_TAG="$raw_tag"
+  PLUGIN_VERSION="${raw_tag#v}"
+else
+  PLUGIN_VERSION=$(mvn -B -q -DforceStdout help:evaluate -Dexpression=project.version)
+  RELEASE_TAG="v${PLUGIN_VERSION}"
+fi
+
+if [[ -z "${PLUGIN_VERSION:-}" || -z "${RELEASE_TAG:-}" ]]; then
+  echo "Unable to resolve plugin version from Git tags or Maven project" >&2
   exit 1
 fi
 
@@ -52,9 +73,11 @@ for version in "${VERSIONS[@]}"; do
   mvn -B -DskipTests \
       -Dmc.version="$version" \
       -Dspigot.api.version="$spigot_version" \
+      -Drevision="$PLUGIN_VERSION" \
+      -Drelease.tag="$RELEASE_TAG" \
       clean package
 
-  jar_name="ChunksLoader-${version}-v${PLUGIN_VERSION}.jar"
+  jar_name="ChunksLoader-${version}-${RELEASE_TAG}.jar"
   jar_path="$PROJECT_DIR/target/$jar_name"
   asset_path="$ASSETS_DIR/$jar_name"
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ChunksLoader
-version: 1.0.0
+version: ${release.tag}
 main: bout2p1_ograines.chunksloader.ChunksLoaderPlugin
 description: Chunk loader plugin
 author: bout2p1_ograines


### PR DESCRIPTION
## Summary
- determine the release tag during CI and pass it through Maven so artifacts adopt the Git tag value
- update Maven configuration and plugin metadata to use a configurable `release.tag` when naming jars
- enhance the asset build script to reuse the release tag and set the Maven revision for local builds

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e5075b09b483219b8d5fccd76c7e3f