### PR TITLE
Add chunk loader activation GUI and inactive state tracking

### DIFF
--- a/src/main/java/bout2p1_ograines/chunksloader/map/BlueMapIntegration.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/map/BlueMapIntegration.java
@@ -210,6 +210,9 @@ public class BlueMapIntegration implements MapIntegration {
     private void addLoaderMarkers(World world, Object markerSet) throws IllegalAccessException, InvocationTargetException, InstantiationException {
         Map<String, Object> markers = getMarkers(markerSet);
         for (ChunkLoaderLocation loader : manager.getLoaders(world.getUID())) {
+            if (!manager.isLoaderActive(loader)) {
+                continue;
+            }
             String id = LOADER_MARKER_PREFIX + loader.worldId() + "_" + loader.x() + "_" + loader.y() + "_" + loader.z();
             Object position = vector3dConstructor.newInstance(loader.x() + 0.5, loader.y() + 0.5, loader.z() + 0.5);
             Object poiMarker = poiMarkerConstructor.newInstance(id, position);

--- a/src/main/java/bout2p1_ograines/chunksloader/map/DynmapIntegration.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/map/DynmapIntegration.java
@@ -179,6 +179,9 @@ public class DynmapIntegration implements MapIntegration {
         if (markerSet == null) {
             return;
         }
+        if (!manager.isLoaderActive(loader)) {
+            return;
+        }
         String markerId = LOADER_MARKER_PREFIX + loader.worldId() + "_" + loader.x() + "_" + loader.y() + "_" + loader.z();
         String label = "Chunk Loader (" + world.getName() + ")";
         createMarkerMethod.invoke(markerSet, markerId, label, world.getName(), loader.x() + 0.5, loader.y() + 0.5,


### PR DESCRIPTION
## Summary
- persist an active flag per chunk loader and expose helpers for toggling and inactive coverage
- add a right-click GUI to toggle loaders and show disabled chunks in gold on /chunksloader map
- ignore inactive loaders in the Dynmap and BlueMap integrations

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e51d884a488321b1d007b5dcee9822