### PR TITLE
Ensure BlueMap marker set is visible by default

### DIFF
--- a/src/main/java/bout2p1_ograines/chunksloader/map/BlueMapIntegration.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/map/BlueMapIntegration.java
@@ -48,6 +48,7 @@ public class BlueMapIntegration implements MapIntegration {
     private Constructor<?> markerSetConstructor;
     private Method markerSetSetLabelMethod;
     private Method markerSetSetToggleableMethod;
+    private Method markerSetSetDefaultHiddenMethod;
     private Method markerSetGetMarkersMethod;
     private Method markerSetSetDirtyMethod;
 
@@ -314,6 +315,11 @@ public class BlueMapIntegration implements MapIntegration {
             markerSetConstructor = markerSetClass.getConstructor(String.class);
             markerSetSetLabelMethod = markerSetClass.getMethod("setLabel", String.class);
             markerSetSetToggleableMethod = markerSetClass.getMethod("setToggleable", boolean.class);
+            try {
+                markerSetSetDefaultHiddenMethod = markerSetClass.getMethod("setDefaultHidden", boolean.class);
+            } catch (NoSuchMethodException ignored) {
+                markerSetSetDefaultHiddenMethod = null;
+            }
             markerSetGetMarkersMethod = markerSetClass.getMethod("getMarkers");
             markerSetSetDirtyMethod = resolveMarkerSetDirtyMethod(markerSetClass);
 
@@ -351,6 +357,9 @@ public class BlueMapIntegration implements MapIntegration {
         Object markerSet = markerSetConstructor.newInstance(MARKER_SET_ID);
         markerSetSetLabelMethod.invoke(markerSet, "Chunk Loaders");
         markerSetSetToggleableMethod.invoke(markerSet, true);
+        if (markerSetSetDefaultHiddenMethod != null) {
+            markerSetSetDefaultHiddenMethod.invoke(markerSet, false);
+        }
         return markerSet;
     }
 


### PR DESCRIPTION
## Summary
- ensure the BlueMap marker set is explicitly marked as visible when it is created
- keep compatibility with older BlueMap API versions by reflecting the method when available

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e56f86851c8321b772fc6c70f2473d