### PR TITLE
Add BlueMap soft dependency

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,8 @@ main: bout2p1_ograines.chunksloader.ChunksLoaderPlugin
 description: Chunk loader plugin
 author: bout2p1_ograines
 api-version: '1.21'
+softdepend:
+  - BlueMap
 commands:
   chunksloader:
     description: Gestion des chunk loaders


### PR DESCRIPTION
## Summary
- declare BlueMap as a soft dependency so ChunksLoader loads after BlueMap and can find its API

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5d3e055208321a49fc0aab3b954cf