### PR TITLE
Refactor BlueMap integration to use official API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
             <id>spigotmc-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>bluecolored</id>
+            <url>https://repo.bluecolored.de/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -39,6 +43,12 @@
             <groupId>com.flowpowered</groupId>
             <artifactId>flow-math</artifactId>
             <version>1.0.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.bluecolored</groupId>
+            <artifactId>bluemap-api</artifactId>
+            <version>2.7.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/bout2p1_ograines/chunksloader/map/BlueMapIntegration.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/map/BlueMapIntegration.java
@@ -3,29 +3,33 @@ package bout2p1_ograines.chunksloader.map;
 import bout2p1_ograines.chunksloader.ChunkLoaderLocation;
 import bout2p1_ograines.chunksloader.ChunkLoaderManager;
 import bout2p1_ograines.chunksloader.ChunksLoaderPlugin;
-
+import com.flowpowered.math.vector.Vector3d;
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import de.bluecolored.bluemap.api.BlueMapMap;
+import de.bluecolored.bluemap.api.BlueMapWorld;
+import de.bluecolored.bluemap.api.markers.Marker;
+import de.bluecolored.bluemap.api.markers.MarkerSet;
+import de.bluecolored.bluemap.api.markers.POIMarker;
+import de.bluecolored.bluemap.api.markers.ShapeMarker;
+import de.bluecolored.bluemap.api.math.Color;
+import de.bluecolored.bluemap.api.math.Shape;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class BlueMapIntegration implements MapIntegration {
 
     private static final String MARKER_SET_ID = "chunksloader";
+    private static final String MARKER_SET_LABEL = "Chunk Loaders";
     private static final String SPAWN_MARKER_ID_PREFIX = "spawn_";
     private static final String LOADER_MARKER_PREFIX = "loader_";
     private static final String LOADER_AREA_SUFFIX = "_area";
@@ -33,12 +37,11 @@ public class BlueMapIntegration implements MapIntegration {
     private final ChunksLoaderPlugin plugin;
     private final ChunkLoaderManager manager;
 
-    private final Map<String, Object> markerSets = new HashMap<>();
+    private final Map<String, MarkerSet> markerSets = new HashMap<>();
 
-    private BlueMapReflection reflection;
-    private Object apiInstance;
-    private Consumer<Object> enableListener;
-    private Consumer<Object> disableListener;
+    private BlueMapAPI api;
+    private Consumer<BlueMapAPI> enableListener;
+    private Consumer<BlueMapAPI> disableListener;
 
     public BlueMapIntegration(ChunksLoaderPlugin plugin) {
         this.plugin = plugin;
@@ -47,36 +50,25 @@ public class BlueMapIntegration implements MapIntegration {
 
     @Override
     public boolean initialize() {
-        reflection = BlueMapReflection.create(plugin);
-        if (reflection == null) {
-            return false;
-        }
-
         enableListener = api -> Bukkit.getScheduler().runTask(plugin, () -> handleEnable(api));
         disableListener = api -> Bukkit.getScheduler().runTask(plugin, this::handleDisable);
 
         try {
-            reflection.registerEnableListener(enableListener);
-            reflection.registerDisableListener(disableListener);
-            reflection.getCurrentInstance().ifPresent(api -> Bukkit.getScheduler().runTask(plugin, () -> handleEnable(api)));
+            BlueMapAPI.onEnable(enableListener);
+            BlueMapAPI.onDisable(disableListener);
+            BlueMapAPI.getInstance().ifPresent(instance ->
+                    Bukkit.getScheduler().runTask(plugin, () -> handleEnable(instance)));
+            return true;
         } catch (Throwable throwable) {
             plugin.getLogger().log(Level.WARNING, "Impossible d'initialiser l'intégration BlueMap", throwable);
             unregisterListeners();
-            reflection = null;
             return false;
         }
-
-        return true;
     }
 
     @Override
     public void shutdown() {
-        if (reflection == null) {
-            return;
-        }
-
         unregisterListeners();
-
         Runnable task = this::handleDisable;
         if (Bukkit.isPrimaryThread()) {
             task.run();
@@ -87,11 +79,21 @@ public class BlueMapIntegration implements MapIntegration {
 
     @Override
     public void onLoadersChanged(World world) {
-        if (apiInstance == null || reflection == null) {
+        if (api == null) {
             return;
         }
 
-        Runnable task = this::updateMarkers;
+        Runnable task = () -> {
+            if (api == null) {
+                return;
+            }
+            if (world != null) {
+                refreshMarkers(List.of(world), false);
+            } else {
+                refreshMarkers(Bukkit.getWorlds(), true);
+            }
+        };
+
         if (Bukkit.isPrimaryThread()) {
             task.run();
         } else {
@@ -99,134 +101,119 @@ public class BlueMapIntegration implements MapIntegration {
         }
     }
 
-    private void unregisterListeners() {
-        if (reflection == null) {
-            return;
-        }
-
-        if (enableListener != null) {
-            try {
-                reflection.unregisterListener(enableListener);
-            } catch (Throwable throwable) {
-                plugin.getLogger().log(Level.WARNING, "Impossible de désinscrire le listener BlueMap", throwable);
-            }
-        }
-
-        if (disableListener != null) {
-            try {
-                reflection.unregisterListener(disableListener);
-            } catch (Throwable throwable) {
-                plugin.getLogger().log(Level.WARNING, "Impossible de désinscrire le listener BlueMap", throwable);
-            }
-        }
-    }
-
-    private void handleEnable(Object apiInstance) {
-        if (reflection == null) {
-            return;
-        }
-
-        this.apiInstance = apiInstance;
-        rebuildMarkerSets();
-        updateMarkers();
+    private void handleEnable(BlueMapAPI apiInstance) {
+        this.api = apiInstance;
+        markerSets.clear();
+        refreshMarkers(Bukkit.getWorlds(), true);
     }
 
     private void handleDisable() {
-        if (reflection == null || apiInstance == null) {
+        if (api == null) {
             markerSets.clear();
-            apiInstance = null;
             return;
         }
 
         try {
-            for (Object map : reflection.getMaps(apiInstance)) {
-                reflection.removeMarkerSet(map, MARKER_SET_ID);
+            for (BlueMapMap map : api.getMaps()) {
+                map.getMarkerSets().remove(MARKER_SET_ID);
             }
         } catch (Throwable throwable) {
             plugin.getLogger().log(Level.WARNING, "Impossible de nettoyer les marqueurs BlueMap", throwable);
         } finally {
             markerSets.clear();
-            apiInstance = null;
+            api = null;
         }
     }
 
-    private void rebuildMarkerSets() {
-        if (apiInstance == null || reflection == null) {
-            return;
-        }
-
-        markerSets.clear();
-
-        try {
-            for (Object map : reflection.getMaps(apiInstance)) {
-                String mapId = reflection.getMapId(map);
-                Object markerSet = reflection.ensureMarkerSet(map, MARKER_SET_ID, "Chunk Loaders");
-                markerSets.put(mapId, markerSet);
-            }
-        } catch (Throwable throwable) {
-            plugin.getLogger().log(Level.WARNING, "Impossible de préparer les calques BlueMap", throwable);
-        }
-    }
-
-    private void updateMarkers() {
-        if (apiInstance == null || reflection == null) {
-            return;
-        }
-
-        Set<String> seenMaps = new HashSet<>();
-
-        try {
-            for (World world : Bukkit.getWorlds()) {
-                Optional<?> optionalWorld = reflection.getWorld(apiInstance, world);
-                if (optionalWorld.isEmpty()) {
-                    continue;
-                }
-
-                Object blueWorld = optionalWorld.get();
-                for (Object map : reflection.getWorldMaps(blueWorld)) {
-                    String mapId = reflection.getMapId(map);
-                    Object markerSet = markerSets.computeIfAbsent(mapId, id -> {
-                        try {
-                            return reflection.ensureMarkerSet(map, MARKER_SET_ID, "Chunk Loaders");
-                        } catch (Throwable throwable) {
-                            plugin.getLogger().log(Level.WARNING, "Impossible de créer le calque BlueMap " + id, throwable);
-                            return null;
-                        }
-                    });
-
-                    if (markerSet == null) {
-                        continue;
-                    }
-
-                    seenMaps.add(mapId);
-                    reflection.clearMarkerSet(markerSet);
-                    addSpawnMarker(world, markerSet);
-                    addLoaderMarkers(world, markerSet);
-                    reflection.markDirty(markerSet);
-                }
-            }
-        } catch (Throwable throwable) {
-            plugin.getLogger().log(Level.WARNING, "Impossible de mettre à jour les marqueurs BlueMap", throwable);
-        }
-
-        // Clean up marker sets that are no longer present on any map.
-        markerSets.entrySet().removeIf(entry -> {
-            if (seenMaps.contains(entry.getKey())) {
-                return false;
-            }
-
+    private void unregisterListeners() {
+        if (enableListener != null) {
             try {
-                reflection.removeMarkerSetById(entry.getKey(), MARKER_SET_ID, apiInstance);
+                BlueMapAPI.unregisterListener(enableListener);
             } catch (Throwable throwable) {
-                plugin.getLogger().log(Level.FINER, "Impossible de retirer le calque BlueMap obsolète " + entry.getKey(), throwable);
+                plugin.getLogger().log(Level.FINE, "Impossible de désinscrire le listener BlueMap (enable)", throwable);
             }
-            return true;
-        });
+            enableListener = null;
+        }
+
+        if (disableListener != null) {
+            try {
+                BlueMapAPI.unregisterListener(disableListener);
+            } catch (Throwable throwable) {
+                plugin.getLogger().log(Level.FINE, "Impossible de désinscrire le listener BlueMap (disable)", throwable);
+            }
+            disableListener = null;
+        }
     }
 
-    private void addLoaderMarkers(World world, Object markerSet) throws Throwable {
-        Map<String, Object> markers = reflection.getMarkers(markerSet);
+    private void refreshMarkers(Collection<World> worlds, boolean cleanMissingMaps) {
+        if (api == null) {
+            return;
+        }
 
+        Set<String> seenMaps = cleanMissingMaps ? new HashSet<>() : null;
+
+        for (World world : worlds) {
+            if (world == null) {
+                continue;
+            }
+
+            api.getWorld(world).ifPresent(blueWorld -> updateWorldMarkers(world, blueWorld, seenMaps));
+        }
+
+        if (cleanMissingMaps && seenMaps != null) {
+            markerSets.entrySet().removeIf(entry -> {
+                if (seenMaps.contains(entry.getKey())) {
+                    return false;
+                }
+
+                try {
+                    api.getMap(entry.getKey()).ifPresent(map -> map.getMarkerSets().remove(MARKER_SET_ID));
+                } catch (Throwable throwable) {
+                    plugin.getLogger().log(Level.FINER,
+                            "Impossible de retirer le calque BlueMap obsolète " + entry.getKey(),
+                            throwable);
+                }
+                return true;
+            });
+        }
+    }
+
+    private void updateWorldMarkers(World bukkitWorld, BlueMapWorld blueWorld, Set<String> seenMaps) {
+        for (BlueMapMap map : blueWorld.getMaps()) {
+            MarkerSet markerSet = ensureMarkerSet(map);
+            if (markerSet == null) {
+                continue;
+            }
+
+            if (seenMaps != null) {
+                seenMaps.add(map.getId());
+            }
+
+            Map<String, Marker> markers = markerSet.getMarkers();
+            markers.clear();
+            addSpawnMarker(bukkitWorld, markers);
+            addLoaderMarkers(bukkitWorld, markers);
+        }
+    }
+
+    private MarkerSet ensureMarkerSet(BlueMapMap map) {
+        MarkerSet markerSet = map.getMarkerSets().get(MARKER_SET_ID);
+        if (markerSet == null) {
+            markerSet = new MarkerSet(MARKER_SET_LABEL);
+            markerSet.setToggleable(true);
+            markerSet.setDefaultHidden(false);
+            map.getMarkerSets().put(MARKER_SET_ID, markerSet);
+        } else {
+            markerSet.setLabel(MARKER_SET_LABEL);
+            markerSet.setToggleable(true);
+            markerSet.setDefaultHidden(false);
+        }
+
+        markerSets.put(map.getId(), markerSet);
+        return markerSet;
+    }
+
+    private void addLoaderMarkers(World world, Map<String, Marker> markers) {
         for (ChunkLoaderLocation loader : manager.getLoaders(world.getUID())) {
             if (!manager.isLoaderActive(loader)) {
                 continue;
@@ -234,10 +221,10 @@ public class BlueMapIntegration implements MapIntegration {
 
             String label = "Chunk Loader (" + world.getName() + ")";
             String markerId = LOADER_MARKER_PREFIX + loader.worldId() + "_" + loader.x() + "_" + loader.y() + "_" + loader.z();
-            Object position = reflection.createVector(loader.x() + 0.5, loader.y() + 0.5, loader.z() + 0.5);
-            Object poi = reflection.createPoiMarker(markerId, position, label);
-            reflection.setPoiDetail(poi, buildLoaderDetail(world, loader));
-            markers.put(markerId, poi);
+
+            POIMarker poiMarker = new POIMarker(label, new Vector3d(loader.x() + 0.5, loader.y() + 0.5, loader.z() + 0.5));
+            poiMarker.setDetail(buildLoaderDetail(world, loader));
+            markers.put(markerId, poiMarker);
 
             addLoaderAreaMarker(world, loader, markers, markerId, label);
         }
@@ -245,9 +232,9 @@ public class BlueMapIntegration implements MapIntegration {
 
     private void addLoaderAreaMarker(World world,
                                      ChunkLoaderLocation loader,
-                                     Map<String, Object> markers,
+                                     Map<String, Marker> markers,
                                      String baseId,
-                                     String label) throws Throwable {
+                                     String label) {
         int radius = plugin.getMapRadius();
         if (radius <= 0) {
             return;
@@ -261,18 +248,18 @@ public class BlueMapIntegration implements MapIntegration {
         double minZ = (chunkZ - radius) * 16.0;
         double maxZ = (chunkZ + radius + 1) * 16.0;
 
-        Object shape = reflection.createRectangle(minX, minZ, maxX, maxZ);
+        Shape shape = Shape.createRect(minX, minZ, maxX, maxZ);
         float y = (float) (loader.y() + 1);
-        Object marker = reflection.createShapeMarker(baseId + LOADER_AREA_SUFFIX, shape, y);
-        reflection.configureShapeMarker(marker,
-                label + " - Zone de " + (radius * 2 + 1) + "x" + (radius * 2 + 1) + " chunks",
-                reflection.createColor(85, 255, 85, 0.2f),
-                reflection.createColor(85, 255, 85, 0.9f),
-                buildLoaderAreaDetail(world, loader, radius));
+        int size = radius * 2 + 1;
+        ShapeMarker marker = new ShapeMarker(label + " - Zone de " + size + "x" + size + " chunks", shape, y);
+        marker.setFillColor(new Color(85, 255, 85, 0.2f));
+        marker.setLineColor(new Color(85, 255, 85, 0.9f));
+        marker.setDepthTestEnabled(false);
+        marker.setDetail(buildLoaderAreaDetail(world, loader, radius));
         markers.put(baseId + LOADER_AREA_SUFFIX, marker);
     }
 
-    private void addSpawnMarker(World world, Object markerSet) throws Throwable {
+    private void addSpawnMarker(World world, Map<String, Marker> markers) {
         UUID worldId = world.getUID();
         String markerId = SPAWN_MARKER_ID_PREFIX + worldId;
 
@@ -285,16 +272,15 @@ public class BlueMapIntegration implements MapIntegration {
         double minZ = (spawnChunkZ - radius) * 16.0;
         double maxZ = (spawnChunkZ + radius + 1) * 16.0;
 
-        Object shape = reflection.createRectangle(minX, minZ, maxX, maxZ);
+        Shape shape = Shape.createRect(minX, minZ, maxX, maxZ);
         float y = (float) world.getSpawnLocation().getY();
-        Object marker = reflection.createShapeMarker(markerId, shape, y);
-        reflection.configureShapeMarker(marker,
-                "Zone de spawn",
-                reflection.createColor(255, 85, 85, 0.35f),
-                reflection.createColor(255, 85, 85, 1.0f),
-                buildSpawnDetail(world, radius));
+        ShapeMarker marker = new ShapeMarker("Zone de spawn", shape, y);
+        marker.setFillColor(new Color(255, 85, 85, 0.35f));
+        marker.setLineColor(new Color(255, 85, 85, 1.0f));
+        marker.setDepthTestEnabled(false);
+        marker.setDetail(buildSpawnDetail(world, radius));
 
-        reflection.getMarkers(markerSet).put(markerId, marker);
+        markers.put(markerId, marker);
     }
 
     private String buildLoaderDetail(World world, ChunkLoaderLocation loader) {
@@ -338,410 +324,4 @@ public class BlueMapIntegration implements MapIntegration {
         }
         return input.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
-
-    private static final class BlueMapReflection {
-        private final ChunksLoaderPlugin plugin;
-
-        private final MethodHandle apiOnEnable;
-        private final MethodHandle apiOnDisable;
-        private final MethodHandle apiUnregister;
-        private final MethodHandle apiGetInstance;
-        private final MethodHandle apiGetMaps;
-        private final MethodHandle apiGetWorld;
-        private final MethodHandle worldGetMaps;
-        private final MethodHandle mapGetMarkerSets;
-        private final MethodHandle mapGetId;
-
-        private final Constructor<?> markerSetConstructor;
-        private final MethodHandle markerSetSetLabel;
-        private final MethodHandle markerSetSetToggleable;
-        private final MethodHandle markerSetSetDefaultHidden;
-        private final MethodHandle markerSetSetHidden;
-        private final MethodHandle markerSetGetMarkers;
-        private final MethodHandle markerSetSetDirty;
-
-        private final Constructor<?> vectorConstructor;
-        private final Constructor<?> poiConstructor;
-        private final MethodHandle poiSetLabel;
-        private final MethodHandle poiSetDetail;
-
-        private final MethodHandle shapeCreateRect;
-        private final Constructor<?> shapeMarkerConstructor;
-        private final MethodHandle shapeMarkerSetLabel;
-        private final MethodHandle shapeMarkerSetFillColor;
-        private final MethodHandle shapeMarkerSetLineColor;
-        private final MethodHandle shapeMarkerSetDepthTest;
-        private final MethodHandle shapeMarkerSetDetail;
-
-        private final Constructor<?> colorConstructor;
-
-        private final MethodHandle mapRemoveMarkerSet;
-
-        private final Class<?> apiClass;
-
-        private BlueMapReflection(ChunksLoaderPlugin plugin,
-                                   MethodHandle apiOnEnable,
-                                   MethodHandle apiOnDisable,
-                                   MethodHandle apiUnregister,
-                                   MethodHandle apiGetInstance,
-                                   MethodHandle apiGetMaps,
-                                   MethodHandle apiGetWorld,
-                                   MethodHandle worldGetMaps,
-                                   MethodHandle mapGetMarkerSets,
-                                   MethodHandle mapGetId,
-                                   Constructor<?> markerSetConstructor,
-                                   MethodHandle markerSetSetLabel,
-                                   MethodHandle markerSetSetToggleable,
-                                   MethodHandle markerSetSetDefaultHidden,
-                                   MethodHandle markerSetSetHidden,
-                                   MethodHandle markerSetGetMarkers,
-                                   MethodHandle markerSetSetDirty,
-                                   Constructor<?> vectorConstructor,
-                                   Constructor<?> poiConstructor,
-                                   MethodHandle poiSetLabel,
-                                   MethodHandle poiSetDetail,
-                                   MethodHandle shapeCreateRect,
-                                   Constructor<?> shapeMarkerConstructor,
-                                   MethodHandle shapeMarkerSetLabel,
-                                   MethodHandle shapeMarkerSetFillColor,
-                                   MethodHandle shapeMarkerSetLineColor,
-                                   MethodHandle shapeMarkerSetDepthTest,
-                                   MethodHandle shapeMarkerSetDetail,
-                                   Constructor<?> colorConstructor,
-                                   MethodHandle mapRemoveMarkerSet,
-                                   Class<?> apiClass) {
-            this.plugin = plugin;
-            this.apiOnEnable = apiOnEnable;
-            this.apiOnDisable = apiOnDisable;
-            this.apiUnregister = apiUnregister;
-            this.apiGetInstance = apiGetInstance;
-            this.apiGetMaps = apiGetMaps;
-            this.apiGetWorld = apiGetWorld;
-            this.worldGetMaps = worldGetMaps;
-            this.mapGetMarkerSets = mapGetMarkerSets;
-            this.mapGetId = mapGetId;
-            this.markerSetConstructor = markerSetConstructor;
-            this.markerSetSetLabel = markerSetSetLabel;
-            this.markerSetSetToggleable = markerSetSetToggleable;
-            this.markerSetSetDefaultHidden = markerSetSetDefaultHidden;
-            this.markerSetSetHidden = markerSetSetHidden;
-            this.markerSetGetMarkers = markerSetGetMarkers;
-            this.markerSetSetDirty = markerSetSetDirty;
-            this.vectorConstructor = vectorConstructor;
-            this.poiConstructor = poiConstructor;
-            this.poiSetLabel = poiSetLabel;
-            this.poiSetDetail = poiSetDetail;
-            this.shapeCreateRect = shapeCreateRect;
-            this.shapeMarkerConstructor = shapeMarkerConstructor;
-            this.shapeMarkerSetLabel = shapeMarkerSetLabel;
-            this.shapeMarkerSetFillColor = shapeMarkerSetFillColor;
-            this.shapeMarkerSetLineColor = shapeMarkerSetLineColor;
-            this.shapeMarkerSetDepthTest = shapeMarkerSetDepthTest;
-            this.shapeMarkerSetDetail = shapeMarkerSetDetail;
-            this.colorConstructor = colorConstructor;
-            this.mapRemoveMarkerSet = mapRemoveMarkerSet;
-            this.apiClass = apiClass;
-        }
-
-        static BlueMapReflection create(ChunksLoaderPlugin plugin) {
-            try {
-                MethodHandles.Lookup lookup = MethodHandles.lookup();
-
-                Class<?> apiClass = Class.forName("de.bluecolored.bluemap.api.BlueMapAPI");
-                Class<?> worldClass = Class.forName("de.bluecolored.bluemap.api.BlueMapWorld");
-                Class<?> mapClass = Class.forName("de.bluecolored.bluemap.api.BlueMapMap");
-                Class<?> markerSetClass = Class.forName("de.bluecolored.bluemap.api.markers.MarkerSet");
-                Class<?> poiMarkerClass = Class.forName("de.bluecolored.bluemap.api.markers.POIMarker");
-                Class<?> shapeClass = Class.forName("de.bluecolored.bluemap.api.math.Shape");
-                Class<?> shapeMarkerClass = Class.forName("de.bluecolored.bluemap.api.markers.ShapeMarker");
-                Class<?> colorClass = Class.forName("de.bluecolored.bluemap.api.math.Color");
-
-                Class<?> vectorClass;
-                try {
-                    vectorClass = Class.forName("com.flowpowered.math.vector.Vector3d");
-                } catch (ClassNotFoundException ignored) {
-                    vectorClass = Class.forName("de.bluecolored.bluemap.api.math.Vector3d");
-                }
-
-                MethodHandle apiOnEnable = lookup.findStatic(apiClass, "onEnable", MethodType.methodType(void.class, Consumer.class));
-                MethodHandle apiOnDisable = lookup.findStatic(apiClass, "onDisable", MethodType.methodType(void.class, Consumer.class));
-                MethodHandle apiUnregister = lookup.findStatic(apiClass, "unregisterListener", MethodType.methodType(void.class, Consumer.class));
-                MethodHandle apiGetInstance = lookup.findStatic(apiClass, "getInstance", MethodType.methodType(Optional.class));
-                MethodHandle apiGetMaps = lookup.findVirtual(apiClass, "getMaps", MethodType.methodType(Collection.class));
-                MethodHandle apiGetWorld = lookup.findVirtual(apiClass, "getWorld", MethodType.methodType(Optional.class, Object.class));
-                MethodHandle worldGetMaps = lookup.findVirtual(worldClass, "getMaps", MethodType.methodType(Collection.class));
-                MethodHandle mapGetMarkerSets = lookup.findVirtual(mapClass, "getMarkerSets", MethodType.methodType(Map.class));
-                MethodHandle mapGetId = lookup.findVirtual(mapClass, "getId", MethodType.methodType(String.class));
-
-                Constructor<?> markerSetConstructor = markerSetClass.getConstructor(String.class);
-                MethodHandle markerSetSetLabel = lookup.findVirtual(markerSetClass, "setLabel", MethodType.methodType(void.class, String.class));
-                MethodHandle markerSetSetToggleable = lookup.findVirtual(markerSetClass, "setToggleable", MethodType.methodType(void.class, boolean.class));
-
-                MethodHandle markerSetSetDefaultHidden;
-                try {
-                    markerSetSetDefaultHidden = lookup.findVirtual(markerSetClass, "setDefaultHidden", MethodType.methodType(void.class, boolean.class));
-                } catch (NoSuchMethodException exception) {
-                    markerSetSetDefaultHidden = null;
-                }
-
-                MethodHandle markerSetSetHidden;
-                try {
-                    markerSetSetHidden = lookup.findVirtual(markerSetClass, "setHidden", MethodType.methodType(void.class, boolean.class));
-                } catch (NoSuchMethodException exception) {
-                    markerSetSetHidden = null;
-                }
-
-                MethodHandle markerSetGetMarkers = lookup.findVirtual(markerSetClass, "getMarkers", MethodType.methodType(Map.class));
-
-                MethodHandle markerSetSetDirty;
-                try {
-                    markerSetSetDirty = lookup.findVirtual(markerSetClass, "setDirty", MethodType.methodType(void.class));
-                } catch (NoSuchMethodException first) {
-                    try {
-                        markerSetSetDirty = lookup.findVirtual(markerSetClass, "setDirty", MethodType.methodType(void.class, boolean.class));
-                    } catch (NoSuchMethodException second) {
-                        markerSetSetDirty = null;
-                    }
-                }
-
-                Constructor<?> vectorConstructor = vectorClass.getConstructor(double.class, double.class, double.class);
-                Constructor<?> poiConstructor = poiMarkerClass.getConstructor(String.class, vectorClass);
-                MethodHandle poiSetLabel = lookup.findVirtual(poiMarkerClass, "setLabel", MethodType.methodType(void.class, String.class));
-                MethodHandle poiSetDetail;
-                try {
-                    poiSetDetail = lookup.findVirtual(poiMarkerClass, "setDetail", MethodType.methodType(void.class, String.class));
-                } catch (NoSuchMethodException exception) {
-                    poiSetDetail = null;
-                }
-
-                MethodHandle shapeCreateRect = lookup.findStatic(shapeClass, "createRect", MethodType.methodType(shapeClass, double.class, double.class, double.class, double.class));
-                Constructor<?> shapeMarkerConstructor = shapeMarkerClass.getConstructor(String.class, shapeClass, float.class);
-                MethodHandle shapeMarkerSetLabel = lookup.findVirtual(shapeMarkerClass, "setLabel", MethodType.methodType(void.class, String.class));
-                MethodHandle shapeMarkerSetFillColor = lookup.findVirtual(shapeMarkerClass, "setFillColor", MethodType.methodType(void.class, colorClass));
-                MethodHandle shapeMarkerSetLineColor = lookup.findVirtual(shapeMarkerClass, "setLineColor", MethodType.methodType(void.class, colorClass));
-                MethodHandle shapeMarkerSetDepthTest;
-                try {
-                    shapeMarkerSetDepthTest = lookup.findVirtual(shapeMarkerClass, "setDepthTest", MethodType.methodType(void.class, boolean.class));
-                } catch (NoSuchMethodException exception) {
-                    try {
-                        shapeMarkerSetDepthTest = lookup.findVirtual(shapeMarkerClass, "setDepthTestEnabled", MethodType.methodType(void.class, boolean.class));
-                    } catch (NoSuchMethodException ignored) {
-                        shapeMarkerSetDepthTest = null;
-                    }
-                }
-                MethodHandle shapeMarkerSetDetail;
-                try {
-                    shapeMarkerSetDetail = lookup.findVirtual(shapeMarkerClass, "setDetail", MethodType.methodType(void.class, String.class));
-                } catch (NoSuchMethodException exception) {
-                    shapeMarkerSetDetail = null;
-                }
-
-                Constructor<?> colorConstructor = colorClass.getConstructor(int.class, int.class, int.class, float.class);
-
-                MethodHandle mapRemoveMarkerSet;
-                try {
-                    mapRemoveMarkerSet = lookup.findVirtual(mapClass, "removeMarkerSet", MethodType.methodType(void.class, String.class));
-                } catch (NoSuchMethodException exception) {
-                    mapRemoveMarkerSet = null;
-                }
-
-                return new BlueMapReflection(plugin,
-                        apiOnEnable,
-                        apiOnDisable,
-                        apiUnregister,
-                        apiGetInstance,
-                        apiGetMaps,
-                        apiGetWorld,
-                        worldGetMaps,
-                        mapGetMarkerSets,
-                        mapGetId,
-                        markerSetConstructor,
-                        markerSetSetLabel,
-                        markerSetSetToggleable,
-                        markerSetSetDefaultHidden,
-                        markerSetSetHidden,
-                        markerSetGetMarkers,
-                        markerSetSetDirty,
-                        vectorConstructor,
-                        poiConstructor,
-                        poiSetLabel,
-                        poiSetDetail,
-                        shapeCreateRect,
-                        shapeMarkerConstructor,
-                        shapeMarkerSetLabel,
-                        shapeMarkerSetFillColor,
-                        shapeMarkerSetLineColor,
-                        shapeMarkerSetDepthTest,
-                        shapeMarkerSetDetail,
-                        colorConstructor,
-                        mapRemoveMarkerSet,
-                        apiClass);
-            } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException exception) {
-                plugin.getLogger().log(Level.INFO, "BlueMap API introuvable, l'intégration est désactivée.");
-                plugin.getLogger().log(Level.FINE, "Détails de l'échec BlueMap", exception);
-                return null;
-            }
-        }
-
-        void registerEnableListener(Consumer<Object> listener) throws Throwable {
-            apiOnEnable.invokeWithArguments(listener);
-        }
-
-        void registerDisableListener(Consumer<Object> listener) throws Throwable {
-            apiOnDisable.invokeWithArguments(listener);
-        }
-
-        void unregisterListener(Consumer<Object> listener) throws Throwable {
-            apiUnregister.invokeWithArguments(listener);
-        }
-
-        Optional<Object> getCurrentInstance() throws Throwable {
-            return (Optional<Object>) apiGetInstance.invokeWithArguments();
-        }
-
-        Collection<?> getMaps(Object apiInstance) throws Throwable {
-            return (Collection<?>) apiGetMaps.invoke(apiInstance);
-        }
-
-        Optional<?> getWorld(Object apiInstance, World world) throws Throwable {
-            return (Optional<?>) apiGetWorld.invoke(apiInstance, world);
-        }
-
-        Collection<?> getWorldMaps(Object blueWorld) throws Throwable {
-            return (Collection<?>) worldGetMaps.invoke(blueWorld);
-        }
-
-        Map<String, Object> getMarkerSetMap(Object map) throws Throwable {
-            return (Map<String, Object>) mapGetMarkerSets.invoke(map);
-        }
-
-        String getMapId(Object map) throws Throwable {
-            return (String) mapGetId.invoke(map);
-        }
-
-        Object ensureMarkerSet(Object map, String markerSetId, String label) throws Throwable {
-            Map<String, Object> sets = getMarkerSetMap(map);
-            Object markerSet = sets.get(markerSetId);
-            if (markerSet == null) {
-                markerSet = markerSetConstructor.newInstance(markerSetId);
-                markerSetSetLabel.invoke(markerSet, label);
-                markerSetSetToggleable.invoke(markerSet, true);
-                if (markerSetSetDefaultHidden != null) {
-                    markerSetSetDefaultHidden.invoke(markerSet, false);
-                }
-                if (markerSetSetHidden != null) {
-                    markerSetSetHidden.invoke(markerSet, false);
-                }
-                sets.put(markerSetId, markerSet);
-            } else {
-                markerSetSetLabel.invoke(markerSet, label);
-                markerSetSetToggleable.invoke(markerSet, true);
-                if (markerSetSetHidden != null) {
-                    markerSetSetHidden.invoke(markerSet, false);
-                }
-            }
-            return markerSet;
-        }
-
-        void clearMarkerSet(Object markerSet) throws Throwable {
-            Map<String, Object> markers = getMarkers(markerSet);
-            markers.clear();
-        }
-
-        Map<String, Object> getMarkers(Object markerSet) throws Throwable {
-            return (Map<String, Object>) markerSetGetMarkers.invoke(markerSet);
-        }
-
-        void markDirty(Object markerSet) {
-            if (markerSetSetDirty == null) {
-                return;
-            }
-            try {
-                int parameters = markerSetSetDirty.type().parameterCount();
-                if (parameters == 1) {
-                    markerSetSetDirty.invoke(markerSet);
-                } else if (parameters == 2) {
-                    markerSetSetDirty.invoke(markerSet, true);
-                } else {
-                    markerSetSetDirty.invokeWithArguments(markerSet);
-                }
-            } catch (Throwable throwable) {
-                plugin.getLogger().log(Level.FINER, "Impossible de marquer le calque BlueMap", throwable);
-            }
-        }
-
-        Object createVector(double x, double y, double z) throws InstantiationException, IllegalAccessException, InvocationTargetException {
-            return vectorConstructor.newInstance(x, y, z);
-        }
-
-        Object createPoiMarker(String id, Object position, String label) throws Throwable {
-            Object marker = poiConstructor.newInstance(id, position);
-            poiSetLabel.invoke(marker, label);
-            return marker;
-        }
-
-        void setPoiDetail(Object marker, String detail) {
-            if (poiSetDetail == null || detail == null || detail.isBlank()) {
-                return;
-            }
-            try {
-                poiSetDetail.invoke(marker, detail);
-            } catch (Throwable throwable) {
-                plugin.getLogger().log(Level.FINER, "Impossible de définir le détail du marqueur POI BlueMap", throwable);
-            }
-        }
-
-        Object createRectangle(double minX, double minZ, double maxX, double maxZ) throws Throwable {
-            return shapeCreateRect.invokeWithArguments(minX, minZ, maxX, maxZ);
-        }
-
-        Object createShapeMarker(String id, Object shape, float y) throws InstantiationException, IllegalAccessException, InvocationTargetException {
-            return shapeMarkerConstructor.newInstance(id, shape, y);
-        }
-
-        void configureShapeMarker(Object marker, String label, Object fill, Object line, String detail) throws Throwable {
-            shapeMarkerSetLabel.invoke(marker, label);
-            shapeMarkerSetFillColor.invoke(marker, fill);
-            shapeMarkerSetLineColor.invoke(marker, line);
-            if (shapeMarkerSetDepthTest != null) {
-                shapeMarkerSetDepthTest.invoke(marker, false);
-            }
-            setShapeMarkerDetail(marker, detail);
-        }
-
-        private void setShapeMarkerDetail(Object marker, String detail) {
-            if (shapeMarkerSetDetail == null || detail == null || detail.isBlank()) {
-                return;
-            }
-            try {
-                shapeMarkerSetDetail.invoke(marker, detail);
-            } catch (Throwable throwable) {
-                plugin.getLogger().log(Level.FINER, "Impossible de définir le détail du marqueur BlueMap", throwable);
-            }
-        }
-
-        Object createColor(int r, int g, int b, float alpha) throws InstantiationException, IllegalAccessException, InvocationTargetException {
-            return colorConstructor.newInstance(r, g, b, alpha);
-        }
-
-        void removeMarkerSet(Object map, String markerSetId) throws Throwable {
-            if (mapRemoveMarkerSet != null) {
-                mapRemoveMarkerSet.invoke(map, markerSetId);
-            } else {
-                getMarkerSetMap(map).remove(markerSetId);
-            }
-        }
-
-        void removeMarkerSetById(String mapId, String markerSetId, Object apiInstance) throws Throwable {
-            for (Object map : getMaps(apiInstance)) {
-                String id = getMapId(map);
-                if (!mapId.equals(id)) {
-                    continue;
-                }
-                removeMarkerSet(map, markerSetId);
-                break;
-            }
-        }
-    }
 }
-


### PR DESCRIPTION
## Summary
- add the BlueMap Maven repository and depend on bluemap-api so the project can compile against the official interfaces
- replace the reflection-heavy BlueMap integration with a direct API implementation that registers enable/disable listeners and rebuilds markers when loader data changes

## Testing
- mvn -B -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e5d597c2788321b3f8b819513fa523