### PR TITLE
Add English documentation and translate plugin messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,65 @@
 # ChunksLoader
 
-This project contains a Bukkit/Spigot chunk loader plugin targeting Minecraft
-releases up to **1.21.9**. The build is parametrised so you can generate jars
-for every compatible version and ship them as release assets.
+ChunksLoader is a Spigot/Paper plugin that lets server owners keep areas of the
+world permanently loaded by placing special beacon-based "chunk loader" blocks.
+The plugin supports Minecraft versions up to **1.21.9**, integrates with
+popular web map plugins, and provides tools for managing loaders in game.
+
+## Features
+
+* **Chunk loader item** – Operators can grant players a beacon that forces the
+  surrounding chunks to stay loaded while it is active.
+* **Placement safeguards** – Loaders cannot be placed in regions that are
+  already covered by another loader to prevent overlapping areas.
+* **Interactive control menu** – Right-clicking a loader opens a GUI to toggle
+  it on or off without breaking the block.
+* **Chunk map preview** – `/chunksloader map` displays a coloured overview of
+  nearby chunks that indicates active loaders, inactive loaders, spawn chunks,
+  and unloaded areas.
+* **Dynmap and BlueMap support** – When the respective plugins are installed,
+  the loader areas are published to the web map with tooltips that show
+  ownership, radius, and status information.
+* **Persistent storage** – Loader locations and states are saved to
+  `chunkloaders.yml`, ensuring that they survive server restarts.
+
+## Commands
+
+| Command | Description | Permission |
+| --- | --- | --- |
+| `/chunksloader give [player]` | Gives the chunk loader item to the specified player (or yourself if omitted). | `chunksloader.give` |
+| `/chunksloader map` | Shows the chunk status map centred on the executing player. | `chunksloader.use` |
+
+If the plugin command is entered without a sub-command, the available options
+are displayed in chat.
+
+## Permissions
+
+| Permission | Default | Description |
+| --- | --- | --- |
+| `chunksloader.use` | Everyone | Allows using `/chunksloader map` and interacting with loader GUIs. |
+| `chunksloader.give` | Operators | Allows giving loader items with `/chunksloader give`. |
+
+## Configuration
+
+The default `config.yml` exposes two options:
+
+```yaml
+loader-radius: 1   # How many chunks around the loader stay active (radius).
+map-radius: 5      # Radius, in chunks, of the `/chunksloader map` preview.
+```
+
+Reload the server or restart it after changing the configuration so the new
+values take effect.
+
+## Map integrations
+
+* **Dynmap** – When Dynmap is installed, the plugin creates a dedicated marker
+  layer that shows each loader's coverage area with descriptions that include
+  coordinates, chunk count, status, and owner information.
+* **BlueMap** – When BlueMap is present, the plugin adds a toggleable marker set
+  to every rendered world and keeps it synchronised with loader changes.
+
+Both integrations are optional; the plugin operates fully without them.
 
 ## Building
 
@@ -33,9 +90,3 @@ The script reads the supported Minecraft versions from
 every resulting jar is copied into the `assets/` directory using the
 `ChunksLoader-<minecraft-version>-<release-tag>.jar` naming scheme so they
 can be uploaded directly to a release.
-
-## Configuration
-
-The plugin ships with a `config.yml` that lets you change the loader radius and
-other behaviour. Adjust the settings to fit your server's needs before
-redeploying the plugin.

--- a/src/main/java/bout2p1_ograines/chunksloader/ChunksLoaderPlugin.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/ChunksLoaderPlugin.java
@@ -67,7 +67,7 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
 
         var pluginCommand = getCommand("chunksloader");
         if (pluginCommand == null) {
-            getLogger().severe("La commande /chunksloader est introuvable dans plugin.yml");
+            getLogger().severe("The /chunksloader command is missing from plugin.yml");
             return;
         }
 
@@ -160,8 +160,8 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
         if (meta != null) {
             meta.setDisplayName(ChatColor.GOLD + "Chunk Loader");
             List<String> lore = new ArrayList<>();
-            lore.add(ChatColor.GRAY + "Charge les chunks voisins");
-            lore.add(ChatColor.GRAY + "Zone " + (loaderRadius * 2 + 1) + "x" + (loaderRadius * 2 + 1));
+            lore.add(ChatColor.GRAY + "Keeps nearby chunks loaded");
+            lore.add(ChatColor.GRAY + "Area " + (loaderRadius * 2 + 1) + "x" + (loaderRadius * 2 + 1));
             meta.setLore(lore);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES);
             PersistentDataContainer container = meta.getPersistentDataContainer();
@@ -185,13 +185,13 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) {
-            sender.sendMessage(ChatColor.RED + "/" + label + " give [player]" + ChatColor.GRAY + " ou " + ChatColor.RED + "/" + label + " map");
+            sender.sendMessage(ChatColor.RED + "/" + label + " give [player]" + ChatColor.GRAY + " or " + ChatColor.RED + "/" + label + " map");
             return true;
         }
 
         if (args[0].equalsIgnoreCase("give")) {
             if (!sender.hasPermission("chunksloader.give")) {
-                sender.sendMessage(ChatColor.RED + "Vous n'avez pas la permission.");
+                sender.sendMessage(ChatColor.RED + "You do not have permission.");
                 return true;
             }
 
@@ -199,12 +199,12 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
             if (args.length >= 2) {
                 target = Bukkit.getPlayerExact(args[1]);
                 if (target == null) {
-                    sender.sendMessage(ChatColor.RED + "Joueur introuvable.");
+                    sender.sendMessage(ChatColor.RED + "Player not found.");
                     return true;
                 }
             } else {
                 if (!(sender instanceof Player player)) {
-                    sender.sendMessage(ChatColor.RED + "Vous devez préciser un joueur.");
+                    sender.sendMessage(ChatColor.RED + "You must specify a player.");
                     return true;
                 }
                 target = player;
@@ -212,20 +212,20 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
 
             ItemStack item = createChunkLoaderItem();
             target.getInventory().addItem(item);
-            sender.sendMessage(ChatColor.GREEN + "Chunk loader donné à " + target.getName() + ".");
+            sender.sendMessage(ChatColor.GREEN + "Gave a chunk loader to " + target.getName() + ".");
             return true;
         }
 
         if (args[0].equalsIgnoreCase("map")) {
             if (!(sender instanceof Player player)) {
-                sender.sendMessage(ChatColor.RED + "Cette commande est réservée aux joueurs.");
+                sender.sendMessage(ChatColor.RED + "This command is only available to players.");
                 return true;
             }
             showMap(player);
             return true;
         }
 
-        sender.sendMessage(ChatColor.RED + "Sous-commande inconnue.");
+        sender.sendMessage(ChatColor.RED + "Unknown sub-command.");
         return true;
     }
 
@@ -237,7 +237,7 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
         int centerChunkX = player.getLocation().getChunk().getX();
         int centerChunkZ = player.getLocation().getChunk().getZ();
         StringBuilder builder = new StringBuilder();
-        builder.append(ChatColor.YELLOW).append("Carte des chunks chargés (" + (radius * 2 + 1) + "x" + (radius * 2 + 1) + "):");
+        builder.append(ChatColor.YELLOW).append("Loaded chunk map (" + (radius * 2 + 1) + "x" + (radius * 2 + 1) + "):");
         player.sendMessage(builder.toString());
 
         for (int dz = radius; dz >= -radius; dz--) {
@@ -264,7 +264,7 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
             player.sendMessage(row.toString());
         }
 
-        player.sendMessage(ChatColor.GREEN + "■" + ChatColor.GRAY + " = Chunk loader" + ChatColor.GOLD + "  ■" + ChatColor.GRAY + " = Chunk loader désactivé" + ChatColor.RED + "  ■" + ChatColor.GRAY + " = Spawn" + ChatColor.DARK_GRAY + "  ■" + ChatColor.GRAY + " = Inactif");
+        player.sendMessage(ChatColor.GREEN + "■" + ChatColor.GRAY + " = Chunk loader" + ChatColor.GOLD + "  ■" + ChatColor.GRAY + " = Disabled chunk loader" + ChatColor.RED + "  ■" + ChatColor.GRAY + " = Spawn" + ChatColor.DARK_GRAY + "  ■" + ChatColor.GRAY + " = Inactive");
     }
 
     @EventHandler
@@ -276,12 +276,12 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
 
         if (!manager.canPlaceLoader(event.getBlockPlaced().getLocation(), loaderRadius)) {
             event.setCancelled(true);
-            event.getPlayer().sendMessage(ChatColor.RED + "Impossible de placer un chunk loader dans une zone déjà chargée.");
+            event.getPlayer().sendMessage(ChatColor.RED + "You cannot place a chunk loader in an area that is already loaded.");
             return;
         }
 
         manager.addLoader(event.getBlockPlaced().getLocation());
-        event.getPlayer().sendMessage(ChatColor.GREEN + "Chunk loader activé.");
+        event.getPlayer().sendMessage(ChatColor.GREEN + "Chunk loader enabled.");
     }
 
     @EventHandler
@@ -294,7 +294,7 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
         event.setDropItems(false);
         if (manager.removeLoader(block)) {
             block.getWorld().dropItemNaturally(block.getLocation(), createChunkLoaderItem());
-            event.getPlayer().sendMessage(ChatColor.YELLOW + "Chunk loader désactivé.");
+            event.getPlayer().sendMessage(ChatColor.YELLOW + "Chunk loader disabled.");
         }
     }
 
@@ -348,15 +348,15 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
 
     private void handleToggle(ChunkLoaderLocation location, Inventory inventory, Player player) {
         if (!manager.getLoaderStates(location.worldId()).containsKey(location)) {
-            player.sendMessage(ChatColor.RED + "Ce chunk loader n'existe plus.");
+            player.sendMessage(ChatColor.RED + "This chunk loader no longer exists.");
             player.closeInventory();
             return;
         }
         boolean active = manager.toggleLoader(location);
         if (active) {
-            player.sendMessage(ChatColor.GREEN + "Chunk loader activé.");
+            player.sendMessage(ChatColor.GREEN + "Chunk loader enabled.");
         } else {
-            player.sendMessage(ChatColor.YELLOW + "Chunk loader désactivé.");
+            player.sendMessage(ChatColor.YELLOW + "Chunk loader disabled.");
         }
         fillChunkLoaderMenu(inventory, location);
     }
@@ -389,11 +389,11 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
             if (active) {
-                meta.setDisplayName(ChatColor.GREEN + "Chunk loader actif");
-                meta.setLore(List.of(ChatColor.GRAY + "Clique pour désactiver le chunk loader."));
+                meta.setDisplayName(ChatColor.GREEN + "Chunk loader active");
+                meta.setLore(List.of(ChatColor.GRAY + "Click to disable the chunk loader."));
             } else {
-                meta.setDisplayName(ChatColor.GOLD + "Chunk loader désactivé");
-                meta.setLore(List.of(ChatColor.GRAY + "Clique pour réactiver le chunk loader."));
+                meta.setDisplayName(ChatColor.GOLD + "Chunk loader disabled");
+                meta.setLore(List.of(ChatColor.GRAY + "Click to reactivate the chunk loader."));
             }
             item.setItemMeta(meta);
         }
@@ -404,7 +404,7 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
         ItemStack item = new ItemStack(Material.BARRIER);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(ChatColor.RED + "Fermer");
+            meta.setDisplayName(ChatColor.RED + "Close");
             item.setItemMeta(meta);
         }
         return item;

--- a/src/main/java/bout2p1_ograines/chunksloader/map/BlueMapIntegration.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/map/BlueMapIntegration.java
@@ -85,7 +85,7 @@ public final class BlueMapIntegration implements MapIntegration {
                 }
             }
         } catch (Exception exception) {
-            plugin.getLogger().log(Level.WARNING, "Impossible de mettre à jour les marqueurs BlueMap", exception);
+            plugin.getLogger().log(Level.WARNING, "Unable to update BlueMap markers", exception);
         }
     }
 
@@ -110,13 +110,13 @@ public final class BlueMapIntegration implements MapIntegration {
     private String buildDetail(LoaderData loader) {
         return new StringBuilder()
             .append("<strong>").append(escape(loader.plainDisplayName())).append("</strong><br/>")
-            .append("Propriétaire : ").append(escape(loader.ownerLabel())).append("<br/>")
-            .append("Rayon : ").append(loader.radius()).append(" chunk(s)<br/>")
-            .append("Chunks : ").append(loader.chunkCount()).append("<br/>")
-            .append("État : ").append(loader.statusLabel()).append("<br/>")
-            .append("Position : ").append(loader.blockX()).append(", ")
+            .append("Owner: ").append(escape(loader.ownerLabel())).append("<br/>")
+            .append("Radius: ").append(loader.radius()).append(" chunk(s)<br/>")
+            .append("Chunks: ").append(loader.chunkCount()).append("<br/>")
+            .append("Status: ").append(loader.statusLabel()).append("<br/>")
+            .append("Position: ").append(loader.blockX()).append(", ")
             .append(loader.blockY()).append(", ").append(loader.blockZ()).append("<br/>")
-            .append("Activité : ").append(escape(loader.formatDuration(Locale.FRANCE)))
+            .append("Uptime: ").append(escape(loader.formatDuration(Locale.UK)))
             .toString();
     }
 
@@ -133,7 +133,7 @@ public final class BlueMapIntegration implements MapIntegration {
         try {
             api.getMaps().forEach(map -> map.getMarkerSets().remove(MARKER_SET_ID));
         } catch (Exception exception) {
-            plugin.getLogger().log(Level.WARNING, "Impossible de nettoyer les marqueurs BlueMap", exception);
+            plugin.getLogger().log(Level.WARNING, "Unable to clear BlueMap markers", exception);
         }
         worldCache.clear();
     }

--- a/src/main/java/bout2p1_ograines/chunksloader/map/DynmapIntegration.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/map/DynmapIntegration.java
@@ -98,7 +98,7 @@ public final class DynmapIntegration implements MapIntegration {
                 }
             }
         } catch (Exception exception) {
-            plugin.getLogger().log(Level.WARNING, "Impossible de mettre à jour les marqueurs Dynmap", exception);
+            plugin.getLogger().log(Level.WARNING, "Unable to update Dynmap markers", exception);
         }
     }
 
@@ -111,18 +111,18 @@ public final class DynmapIntegration implements MapIntegration {
                 deleteMarker.invoke(marker);
             }
         } catch (Exception exception) {
-            plugin.getLogger().log(Level.WARNING, "Impossible de nettoyer les marqueurs Dynmap", exception);
+            plugin.getLogger().log(Level.WARNING, "Unable to clear Dynmap markers", exception);
         }
     }
 
     private String buildDescription(LoaderData loader) {
         return new StringBuilder()
             .append("<strong>").append(html(loader.plainDisplayName())).append("</strong><br/>")
-            .append("Propriétaire : ").append(html(loader.ownerLabel())).append("<br/>")
-            .append("Rayon : ").append(loader.radius()).append(" chunk(s)<br/>")
-            .append("Chunks : ").append(loader.chunkCount()).append("<br/>")
-            .append("État : ").append(loader.statusLabel()).append("<br/>")
-            .append("Position : ").append(loader.blockX()).append(", ")
+            .append("Owner: ").append(html(loader.ownerLabel())).append("<br/>")
+            .append("Radius: ").append(loader.radius()).append(" chunk(s)<br/>")
+            .append("Chunks: ").append(loader.chunkCount()).append("<br/>")
+            .append("Status: ").append(loader.statusLabel()).append("<br/>")
+            .append("Position: ").append(loader.blockX()).append(", ")
             .append(loader.blockY()).append(", ").append(loader.blockZ())
             .toString();
     }
@@ -204,7 +204,7 @@ public final class DynmapIntegration implements MapIntegration {
         } catch (ClassNotFoundException ignored) {
             return Optional.empty();
         } catch (Exception exception) {
-            plugin.getLogger().log(Level.WARNING, "Impossible d'initialiser l'intégration Dynmap", exception);
+            plugin.getLogger().log(Level.WARNING, "Unable to initialise Dynmap integration", exception);
             return Optional.empty();
         }
     }

--- a/src/main/java/bout2p1_ograines/chunksloader/map/LoaderData.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/map/LoaderData.java
@@ -38,11 +38,11 @@ public record LoaderData(
     }
 
     public String statusLabel() {
-        return active ? "Actif" : "Inactif";
+        return active ? "Active" : "Inactive";
     }
 
     public String ownerLabel() {
-        return ownerName == null || ownerName.isBlank() ? "Inconnu" : ownerName;
+        return ownerName == null || ownerName.isBlank() ? "Unknown" : ownerName;
     }
 
     public String formatDuration(Locale locale) {
@@ -55,7 +55,7 @@ public record LoaderData(
         hours %= 24L;
         StringBuilder builder = new StringBuilder();
         if (days > 0) {
-            builder.append(days).append('j').append(' ');
+            builder.append(days).append('d').append(' ');
         }
         if (hours > 0 || builder.length() > 0) {
             builder.append(hours).append('h').append(' ');

--- a/src/main/java/bout2p1_ograines/chunksloader/map/MapIntegrationManager.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/map/MapIntegrationManager.java
@@ -28,7 +28,7 @@ public final class MapIntegrationManager implements ChunkLoaderListener {
     public void initialize() {
         dynmapIntegration = DynmapIntegration.create(plugin)
             .map(integration -> {
-                plugin.getLogger().info("Intégration Dynmap activée.");
+                plugin.getLogger().info("Dynmap integration enabled.");
                 return integration;
             })
             .orElse(null);
@@ -67,7 +67,7 @@ public final class MapIntegrationManager implements ChunkLoaderListener {
             return;
         }
         blueMapIntegration = new BlueMapIntegration(plugin, api);
-        plugin.getLogger().info("Intégration BlueMap activée.");
+        plugin.getLogger().info("BlueMap integration enabled.");
         updateAll();
     }
 
@@ -75,7 +75,7 @@ public final class MapIntegrationManager implements ChunkLoaderListener {
         if (blueMapIntegration != null && blueMapIntegration.isFor(api)) {
             blueMapIntegration.shutdown();
             blueMapIntegration = null;
-            plugin.getLogger().info("Intégration BlueMap désactivée.");
+            plugin.getLogger().info("BlueMap integration disabled.");
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ softdepend:
   - BlueMap
 commands:
   chunksloader:
-    description: Gestion des chunk loaders
+    description: Manage chunk loaders
     usage: /<command> give|map
     permission: chunksloader.use
 permissions:


### PR DESCRIPTION
## Summary
- replace the README with a comprehensive English overview of the plugin's features, commands, permissions, configuration, and integrations
- translate all user-facing chat strings, GUI labels, map tooltips, and log messages to English for consistency
- update plugin metadata to use English wording and keep locale-dependent formatting readable

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e7a554980883218a037d39497681c5