### PR TITLE
Add simulated player emulation toggle to chunk loaders

### DIFF
--- a/src/main/java/bout2p1_ograines/chunksloader/ChunkLoaderManager.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/ChunkLoaderManager.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -24,8 +25,9 @@ public class ChunkLoaderManager {
     private final ChunksLoaderPlugin plugin;
     private final File storageFile;
 
-    private final Map<UUID, Map<ChunkLoaderLocation, Boolean>> loadersByWorld = new HashMap<>();
+    private final Map<UUID, Map<ChunkLoaderLocation, ChunkLoaderState>> loadersByWorld = new HashMap<>();
     private final List<ChunkLoaderListener> listeners = new ArrayList<>();
+    private final PlayerEmulationController playerEmulationController;
 
     public ChunkLoaderManager(ChunksLoaderPlugin plugin) {
         this.plugin = plugin;
@@ -34,6 +36,7 @@ public class ChunkLoaderManager {
             //noinspection ResultOfMethodCallIgnored
             plugin.getDataFolder().mkdirs();
         }
+        this.playerEmulationController = new PlayerEmulationController(plugin);
     }
 
     public void addListener(ChunkLoaderListener listener) {
@@ -64,16 +67,28 @@ public class ChunkLoaderManager {
             if (list == null) {
                 continue;
             }
-            Map<ChunkLoaderLocation, Boolean> set = new HashMap<>();
+            Map<ChunkLoaderLocation, ChunkLoaderState> set = new HashMap<>();
             for (Object entry : list) {
                 if (entry instanceof Map<?, ?> map) {
                     Integer x = mapValue(map, "x");
                     Integer y = mapValue(map, "y");
                     Integer z = mapValue(map, "z");
                     Boolean active = mapBoolean(map, "active");
+                    Boolean emulatePlayer = mapBoolean(map, "player");
+                    String playerName = mapString(map, "playerName");
                     if (x != null && y != null && z != null) {
                         ChunkLoaderLocation location = new ChunkLoaderLocation(uuid, x, y, z);
-                        set.put(location, active == null || active);
+                        boolean isActive = active == null || active;
+                        boolean emulate = emulatePlayer != null && emulatePlayer;
+                        if (emulate && !playerEmulationController.isPlayerCommandAvailable()) {
+                            plugin.getLogger().warning("Simulated players are not supported on this server. Disabling player emulation for loader at " + x + ", " + y + ", " + z + ".");
+                            emulate = false;
+                        }
+                        if (emulate && (playerName == null || playerName.isBlank())) {
+                            playerName = generateSimulatedPlayerName(location);
+                        }
+                        ChunkLoaderState state = new ChunkLoaderState(isActive, emulate, playerName);
+                        set.put(location, state);
                     } else {
                         plugin.getLogger().warning("Ignoring invalid chunk loader entry for world '" + worldId + "' in " + STORAGE_FILE);
                     }
@@ -90,15 +105,22 @@ public class ChunkLoaderManager {
 
     public void save() {
         FileConfiguration configuration = new YamlConfiguration();
-        for (Map.Entry<UUID, Map<ChunkLoaderLocation, Boolean>> entry : loadersByWorld.entrySet()) {
+        for (Map.Entry<UUID, Map<ChunkLoaderLocation, ChunkLoaderState>> entry : loadersByWorld.entrySet()) {
             List<Map<String, Object>> list = new ArrayList<>();
-            for (Map.Entry<ChunkLoaderLocation, Boolean> loaderEntry : entry.getValue().entrySet()) {
+            for (Map.Entry<ChunkLoaderLocation, ChunkLoaderState> loaderEntry : entry.getValue().entrySet()) {
                 ChunkLoaderLocation location = loaderEntry.getKey();
+                ChunkLoaderState state = loaderEntry.getValue();
                 Map<String, Object> map = new HashMap<>();
                 map.put("x", location.x());
                 map.put("y", location.y());
                 map.put("z", location.z());
-                map.put("active", loaderEntry.getValue() != null && loaderEntry.getValue());
+                map.put("active", state != null && state.isActive());
+                if (state != null && state.isPlayerEmulationEnabled()) {
+                    map.put("player", true);
+                }
+                if (state != null && state.getSimulatedPlayerName() != null) {
+                    map.put("playerName", state.getSimulatedPlayerName());
+                }
                 list.add(map);
             }
             configuration.set(entry.getKey().toString(), list);
@@ -133,9 +155,17 @@ public class ChunkLoaderManager {
         return null;
     }
 
+    private String mapString(Map<?, ?> map, String key) {
+        Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+        return String.valueOf(value);
+    }
+
     public boolean isChunkLoaderBlock(Block block) {
         UUID worldId = block.getWorld().getUID();
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.get(worldId);
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(worldId);
         if (loaders == null) {
             return false;
         }
@@ -152,7 +182,11 @@ public class ChunkLoaderManager {
             return false;
         }
 
-        for (ChunkLoaderLocation loader : getLoaderStates(worldId).keySet()) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> states = loadersByWorld.get(worldId);
+        if (states == null) {
+            return true;
+        }
+        for (ChunkLoaderLocation loader : states.keySet()) {
             if (overlaps(chunkX, chunkZ, loader, radius)) {
                 return false;
             }
@@ -162,9 +196,9 @@ public class ChunkLoaderManager {
 
     public void addLoader(Location location) {
         UUID worldId = location.getWorld().getUID();
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.computeIfAbsent(worldId, k -> new HashMap<>());
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.computeIfAbsent(worldId, k -> new HashMap<>());
         ChunkLoaderLocation loaderLocation = new ChunkLoaderLocation(worldId, location.getBlockX(), location.getBlockY(), location.getBlockZ());
-        loaders.put(loaderLocation, true);
+        loaders.put(loaderLocation, new ChunkLoaderState(true, false, null));
         save();
         applyForcedChunks(location.getWorld());
         notifyListeners(location.getWorld());
@@ -173,13 +207,14 @@ public class ChunkLoaderManager {
     public boolean removeLoader(Block block) {
         World world = block.getWorld();
         UUID worldId = world.getUID();
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.get(worldId);
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(worldId);
         if (loaders == null) {
             return false;
         }
         ChunkLoaderLocation location = new ChunkLoaderLocation(worldId, block.getX(), block.getY(), block.getZ());
-        Boolean removed = loaders.remove(location);
+        ChunkLoaderState removed = loaders.remove(location);
         if (removed != null) {
+            playerEmulationController.disable(location, removed);
             if (loaders.isEmpty()) {
                 loadersByWorld.remove(worldId);
             }
@@ -192,13 +227,13 @@ public class ChunkLoaderManager {
     }
 
     public Set<ChunkLoaderLocation> getLoaders(UUID worldId) {
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.get(worldId);
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(worldId);
         if (loaders == null) {
             return Set.of();
         }
         Set<ChunkLoaderLocation> active = new HashSet<>();
-        for (Map.Entry<ChunkLoaderLocation, Boolean> entry : loaders.entrySet()) {
-            if (Boolean.TRUE.equals(entry.getValue())) {
+        for (Map.Entry<ChunkLoaderLocation, ChunkLoaderState> entry : loaders.entrySet()) {
+            if (entry.getValue() != null && entry.getValue().isActive()) {
                 active.add(entry.getKey());
             }
         }
@@ -207,7 +242,7 @@ public class ChunkLoaderManager {
 
     public Set<ChunkLoaderLocation> getAllLoaders() {
         Set<ChunkLoaderLocation> all = new HashSet<>();
-        for (Map<ChunkLoaderLocation, Boolean> loaders : loadersByWorld.values()) {
+        for (Map<ChunkLoaderLocation, ChunkLoaderState> loaders : loadersByWorld.values()) {
             all.addAll(loaders.keySet());
         }
         return all;
@@ -232,21 +267,24 @@ public class ChunkLoaderManager {
     public void applyForcedChunks(World world) {
         clearForcedChunks(world);
         int radius = plugin.getLoaderRadius();
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.get(world.getUID());
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(world.getUID());
         if (loaders == null) {
+            playerEmulationController.clearWorld(world.getUID());
             return;
         }
-        for (Map.Entry<ChunkLoaderLocation, Boolean> entry : loaders.entrySet()) {
-            if (Boolean.TRUE.equals(entry.getValue())) {
+        for (Map.Entry<ChunkLoaderLocation, ChunkLoaderState> entry : loaders.entrySet()) {
+            if (entry.getValue() != null && entry.getValue().isActive()) {
                 forceChunkArea(world, entry.getKey(), radius);
             }
         }
+        playerEmulationController.syncWorld(world, loaders);
     }
 
     public void clearAllForcedChunks() {
         for (World world : Bukkit.getWorlds()) {
             clearForcedChunks(world);
         }
+        playerEmulationController.clearAll();
     }
 
     private void forceChunkArea(World world, ChunkLoaderLocation loader, int radius) {
@@ -306,12 +344,12 @@ public class ChunkLoaderManager {
     public Set<ChunkCoordinate> getInactiveChunkArea(World world) {
         Set<ChunkCoordinate> inactive = new HashSet<>();
         int radius = plugin.getLoaderRadius();
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.get(world.getUID());
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(world.getUID());
         if (loaders == null) {
             return inactive;
         }
-        for (Map.Entry<ChunkLoaderLocation, Boolean> entry : loaders.entrySet()) {
-            if (Boolean.TRUE.equals(entry.getValue())) {
+        for (Map.Entry<ChunkLoaderLocation, ChunkLoaderState> entry : loaders.entrySet()) {
+            if (entry.getValue() != null && entry.getValue().isActive()) {
                 continue;
             }
             ChunkLoaderLocation loader = entry.getKey();
@@ -326,20 +364,25 @@ public class ChunkLoaderManager {
         return inactive;
     }
 
-    public Map<ChunkLoaderLocation, Boolean> getLoaderStates(UUID worldId) {
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.get(worldId);
+    public Map<ChunkLoaderLocation, ChunkLoaderState> getLoaderStates(UUID worldId) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(worldId);
         if (loaders == null) {
             return Map.of();
         }
-        return Map.copyOf(loaders);
+        Map<ChunkLoaderLocation, ChunkLoaderState> copy = new HashMap<>();
+        for (Map.Entry<ChunkLoaderLocation, ChunkLoaderState> entry : loaders.entrySet()) {
+            copy.put(entry.getKey(), entry.getValue() == null ? null : new ChunkLoaderState(entry.getValue()));
+        }
+        return Map.copyOf(copy);
     }
 
     public boolean isLoaderActive(ChunkLoaderLocation location) {
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.get(location.worldId());
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(location.worldId());
         if (loaders == null) {
             return false;
         }
-        return Boolean.TRUE.equals(loaders.get(location));
+        ChunkLoaderState state = loaders.get(location);
+        return state != null && state.isActive();
     }
 
     public boolean isLoaderActive(Block block) {
@@ -348,14 +391,15 @@ public class ChunkLoaderManager {
     }
 
     public void setLoaderActive(ChunkLoaderLocation location, boolean active) {
-        Map<ChunkLoaderLocation, Boolean> loaders = loadersByWorld.get(location.worldId());
-        if (loaders == null || !loaders.containsKey(location)) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(location.worldId());
+        if (loaders == null) {
             return;
         }
-        if (Boolean.TRUE.equals(loaders.get(location)) == active) {
+        ChunkLoaderState state = loaders.get(location);
+        if (state == null || state.isActive() == active) {
             return;
         }
-        loaders.put(location, active);
+        state.setActive(active);
         save();
         World world = Bukkit.getWorld(location.worldId());
         if (world != null) {
@@ -368,12 +412,115 @@ public class ChunkLoaderManager {
     }
 
     public boolean toggleLoader(ChunkLoaderLocation location) {
-        if (!getLoaderStates(location.worldId()).containsKey(location)) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(location.worldId());
+        if (loaders == null || !loaders.containsKey(location)) {
             return false;
         }
         boolean currentlyActive = isLoaderActive(location);
         setLoaderActive(location, !currentlyActive);
         return !currentlyActive;
+    }
+
+    public ChunkLoaderState getLoaderState(ChunkLoaderLocation location) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(location.worldId());
+        if (loaders == null) {
+            return null;
+        }
+        ChunkLoaderState state = loaders.get(location);
+        if (state == null) {
+            return null;
+        }
+        return new ChunkLoaderState(state);
+    }
+
+    public boolean hasLoader(ChunkLoaderLocation location) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(location.worldId());
+        return loaders != null && loaders.containsKey(location);
+    }
+
+    public boolean isPlayerEmulationEnabled(ChunkLoaderLocation location) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(location.worldId());
+        if (loaders == null) {
+            return false;
+        }
+        ChunkLoaderState state = loaders.get(location);
+        return state != null && state.isPlayerEmulationEnabled();
+    }
+
+    public boolean setPlayerEmulation(ChunkLoaderLocation location, boolean emulate) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(location.worldId());
+        if (loaders == null) {
+            return false;
+        }
+        ChunkLoaderState state = loaders.get(location);
+        if (state == null) {
+            return false;
+        }
+        if (state.isPlayerEmulationEnabled() == emulate) {
+            return true;
+        }
+        if (emulate && !playerEmulationController.isPlayerCommandAvailable()) {
+            return false;
+        }
+        if (emulate && (state.getSimulatedPlayerName() == null || state.getSimulatedPlayerName().isBlank())) {
+            state.setSimulatedPlayerName(generateSimulatedPlayerName(location));
+        }
+        state.setPlayerEmulationEnabled(emulate);
+        save();
+        World world = Bukkit.getWorld(location.worldId());
+        if (world != null) {
+            applyForcedChunks(world);
+            notifyListeners(world);
+        } else {
+            applyForcedChunks();
+            notifyListeners(null);
+        }
+        return true;
+    }
+
+    public boolean togglePlayerEmulation(ChunkLoaderLocation location) {
+        Map<ChunkLoaderLocation, ChunkLoaderState> loaders = loadersByWorld.get(location.worldId());
+        if (loaders == null || !loaders.containsKey(location)) {
+            return false;
+        }
+        ChunkLoaderState state = loaders.get(location);
+        boolean target = state == null || !state.isPlayerEmulationEnabled();
+        if (!setPlayerEmulation(location, target)) {
+            return false;
+        }
+        return target;
+    }
+
+    public boolean canEmulatePlayers() {
+        return playerEmulationController.isPlayerCommandAvailable();
+    }
+
+    public void clearAllPlayerEmulators() {
+        playerEmulationController.clearAll();
+    }
+
+    private String generateSimulatedPlayerName(ChunkLoaderLocation location) {
+        long hash = 1469598103934665603L;
+        hash = mixHash(hash, location.worldId().getMostSignificantBits());
+        hash = mixHash(hash, location.worldId().getLeastSignificantBits());
+        hash = mixHash(hash, location.x());
+        hash = mixHash(hash, location.y());
+        hash = mixHash(hash, location.z());
+        String base = Long.toUnsignedString(hash, 36).toUpperCase(Locale.ROOT);
+        String name = "CL" + base;
+        if (name.length() > 16) {
+            name = name.substring(0, 16);
+        }
+        while (name.length() < 3) {
+            name = name + "0";
+        }
+        return name;
+    }
+
+    private long mixHash(long current, long value) {
+        current ^= value;
+        current *= 1099511628211L;
+        return current;
     }
 
 }

--- a/src/main/java/bout2p1_ograines/chunksloader/ChunkLoaderState.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/ChunkLoaderState.java
@@ -1,0 +1,45 @@
+package bout2p1_ograines.chunksloader;
+
+/**
+ * Represents the state of a chunk loader, including whether it is active and whether
+ * it should emulate a player.
+ */
+public final class ChunkLoaderState {
+    private boolean active;
+    private boolean playerEmulationEnabled;
+    private String simulatedPlayerName;
+
+    public ChunkLoaderState(boolean active, boolean playerEmulationEnabled, String simulatedPlayerName) {
+        this.active = active;
+        this.playerEmulationEnabled = playerEmulationEnabled;
+        this.simulatedPlayerName = simulatedPlayerName;
+    }
+
+    public ChunkLoaderState(ChunkLoaderState other) {
+        this(other.active, other.playerEmulationEnabled, other.simulatedPlayerName);
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public boolean isPlayerEmulationEnabled() {
+        return playerEmulationEnabled;
+    }
+
+    public void setPlayerEmulationEnabled(boolean playerEmulationEnabled) {
+        this.playerEmulationEnabled = playerEmulationEnabled;
+    }
+
+    public String getSimulatedPlayerName() {
+        return simulatedPlayerName;
+    }
+
+    public void setSimulatedPlayerName(String simulatedPlayerName) {
+        this.simulatedPlayerName = simulatedPlayerName;
+    }
+}

--- a/src/main/java/bout2p1_ograines/chunksloader/PlayerEmulationController.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/PlayerEmulationController.java
@@ -1,0 +1,156 @@
+package bout2p1_ograines.chunksloader;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Handles spawning and removing simulated players using the vanilla {@code /player}
+ * command introduced in Minecraft 1.21.
+ */
+public class PlayerEmulationController {
+    private final ChunksLoaderPlugin plugin;
+    private final Map<ChunkLoaderLocation, String> activePlayers = new HashMap<>();
+    private final boolean playerCommandAvailable;
+
+    public PlayerEmulationController(ChunksLoaderPlugin plugin) {
+        this.plugin = plugin;
+        this.playerCommandAvailable = detectPlayerCommand();
+    }
+
+    private boolean detectPlayerCommand() {
+        try {
+            Object commandMap = Bukkit.getServer().getClass().getMethod("getCommandMap").invoke(Bukkit.getServer());
+            Object command = commandMap.getClass().getMethod("getCommand", String.class).invoke(commandMap, "player");
+            return command != null;
+        } catch (ReflectiveOperationException exception) {
+            plugin.getLogger().warning("Unable to detect support for the /player command: " + exception.getMessage());
+            return false;
+        }
+    }
+
+    public boolean isPlayerCommandAvailable() {
+        return playerCommandAvailable;
+    }
+
+    public void syncWorld(World world, Map<ChunkLoaderLocation, ChunkLoaderState> states) {
+        if (!playerCommandAvailable) {
+            clearWorld(world.getUID());
+            return;
+        }
+        Set<ChunkLoaderLocation> desired = new HashSet<>();
+        for (Map.Entry<ChunkLoaderLocation, ChunkLoaderState> entry : states.entrySet()) {
+            ChunkLoaderLocation location = entry.getKey();
+            ChunkLoaderState state = entry.getValue();
+            if (!Objects.equals(location.worldId(), world.getUID())) {
+                continue;
+            }
+            if (state.isActive() && state.isPlayerEmulationEnabled()) {
+                desired.add(location);
+                ensureSpawned(location, state);
+            } else {
+                disable(location, state);
+            }
+        }
+        for (Map.Entry<ChunkLoaderLocation, String> entry : new HashMap<>(activePlayers).entrySet()) {
+            ChunkLoaderLocation location = entry.getKey();
+            if (!Objects.equals(location.worldId(), world.getUID())) {
+                continue;
+            }
+            if (!desired.contains(location)) {
+                killPlayer(entry.getValue());
+                activePlayers.remove(location);
+            }
+        }
+    }
+
+    public void ensureSpawned(ChunkLoaderLocation location, ChunkLoaderState state) {
+        if (!playerCommandAvailable) {
+            return;
+        }
+        String name = state.getSimulatedPlayerName();
+        if (name == null || name.isBlank()) {
+            return;
+        }
+        if (activePlayers.containsKey(location)) {
+            return;
+        }
+        Location spawnLocation = resolveLocation(location);
+        if (spawnLocation == null) {
+            return;
+        }
+        killPlayer(name);
+        if (spawnPlayer(name, spawnLocation)) {
+            activePlayers.put(location, name);
+        }
+    }
+
+    public void disable(ChunkLoaderLocation location, ChunkLoaderState state) {
+        String tracked = activePlayers.remove(location);
+        String name = tracked != null ? tracked : state.getSimulatedPlayerName();
+        if (name != null && !name.isBlank()) {
+            killPlayer(name);
+        }
+    }
+
+    public void clearAll() {
+        for (String name : new HashSet<>(activePlayers.values())) {
+            killPlayer(name);
+        }
+        activePlayers.clear();
+    }
+
+    public void clearWorld(UUID worldId) {
+        for (Map.Entry<ChunkLoaderLocation, String> entry : new HashMap<>(activePlayers).entrySet()) {
+            if (Objects.equals(entry.getKey().worldId(), worldId)) {
+                killPlayer(entry.getValue());
+                activePlayers.remove(entry.getKey());
+            }
+        }
+    }
+
+    private Location resolveLocation(ChunkLoaderLocation location) {
+        World world = Bukkit.getWorld(location.worldId());
+        if (world == null) {
+            return null;
+        }
+        return new Location(world, location.x() + 0.5, location.y(), location.z() + 0.5, 0.0f, 0.0f);
+    }
+
+    private boolean spawnPlayer(String name, Location location) {
+        String dimension = switch (location.getWorld().getEnvironment()) {
+            case NETHER -> "minecraft:the_nether";
+            case THE_END -> "minecraft:the_end";
+            case NORMAL -> "minecraft:overworld";
+            default -> location.getWorld().getKey().toString();
+        };
+        String command = String.format(Locale.ROOT,
+            "player %s spawn at %.2f %.2f %.2f in %s", name,
+            location.getX(), location.getY(), location.getZ(), dimension);
+        CommandSender console = Bukkit.getConsoleSender();
+        boolean success = Bukkit.dispatchCommand(console, command);
+        if (!success) {
+            plugin.getLogger().warning("Failed to spawn simulated player '" + name + "' using command: " + command);
+        }
+        return success;
+    }
+
+    private void killPlayer(String name) {
+        if (!playerCommandAvailable || name == null || name.isBlank()) {
+            return;
+        }
+        CommandSender console = Bukkit.getConsoleSender();
+        if (!Bukkit.dispatchCommand(console, "player " + name + " kill")) {
+            plugin.getLogger().warning("Failed to remove simulated player '" + name + "'.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track per-loader state for active status and player emulation, persisting the data
- add a player emulation controller that spawns or removes simulated players with the vanilla `/player` command
- extend the chunk loader menu with a toggle to enable or disable player emulation for each loader

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68eb89997ea08321aef785429f174f42