### PR TITLE
Improve simulated player troubleshooting on Purpur

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,31 @@ When emulation is enabled the loader spawns an invisible spectator-mode player
 at its location while it is active. Older server versions show the toggle as a
 greyed-out dye and keep the feature disabled automatically.【F:src/main/java/bout2p1_ograines/chunksloader/ChunksLoaderPlugin.java†L370-L468】
 
+> **Troubleshooting:** The plugin prints `Unable to initialise simulated
+> network connection; player emulation disabled.` when it cannot find the
+> required Minecraft server classes via reflection. This happens on server
+> builds older than 1.21 or when the plugin jar does not match the running
+> Minecraft version. To enable the feature, run the plugin on a supported
+> Spigot/Paper 1.21+ server (or build the plugin against your target version)
+> and restart so the simulated connection can be created successfully.
+> Purpur and other Paper-derived forks are supported as long as the jar matches
+> the exact Minecraft version you are running—for example, use
+> `ChunksLoader-1.21.9-*.jar` on Purpur **1.21.9** (or rebuild with
+> `./gradlew -PmcVersion=1.21.9 build` before restarting the server). When the
+> warning still appears, check the server console for the extended message that
+> now lists the exact missing class, constructor, or field (for example `no
+> connection field or setter on ServerPlayer`). That detail normally means a
+> mismatched jar was loaded; if the versions do match, share the full warning
+> line when asking for help so we can identify which Purpur build changed the
+> internals.
+
+> **Can another plugin provide the simulated players?** No. ChunksLoader spawns
+> its emulated players by reflectively calling the internal server classes that
+> exist in Mojang's 1.21+ server jars. Because there is no public Bukkit, Spigot
+> or Paper API for this behaviour, the feature cannot be proxied through or
+> enabled by installing a separate plugin—the server itself must expose the
+> required classes.
+
 ## Map integrations
 
 * **Dynmap** – When Dynmap is installed, the plugin creates a dedicated marker

--- a/src/main/java/bout2p1_ograines/chunksloader/PlayerEmulationController.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/PlayerEmulationController.java
@@ -393,7 +393,23 @@ public class PlayerEmulationController {
                     connectionField = findField(serverPlayerClass, null, "connection");
                 }
                 if (serverGamePacketListenerConstructor == null || (connectionField == null && connectionSetterMethod == null) || connectionClass == null) {
-                    plugin.getLogger().warning("Unable to initialise simulated network connection; player emulation disabled.");
+                    List<String> reasons = new ArrayList<>();
+                    if (serverGamePacketListenerClass == null) {
+                        reasons.add("missing net.minecraft.server.network.ServerGamePacketListenerImpl");
+                    } else if (serverGamePacketListenerConstructor == null) {
+                        reasons.add("unable to locate a usable ServerGamePacketListenerImpl constructor");
+                    }
+                    if (connectionClass == null) {
+                        reasons.add("missing net.minecraft.network.Connection class");
+                    }
+                    if (packetListenerClass == null) {
+                        reasons.add("missing net.minecraft.network.PacketListener class");
+                    }
+                    if (connectionField == null && connectionSetterMethod == null) {
+                        reasons.add("no connection field or setter on ServerPlayer");
+                    }
+                    String suffix = reasons.isEmpty() ? "" : " Details: " + String.join("; ", reasons);
+                    plugin.getLogger().warning("Unable to initialise simulated network connection; player emulation disabled." + suffix);
                     return null;
                 }
 


### PR DESCRIPTION
## Summary
- expand the simulated network warning to include the missing classes, constructors, or fields
- document how to use the extended log output when diagnosing Purpur 1.21.9 player emulation issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebb62fca30832198b9885c443fa2a9