### PR TITLE
Add permission gate to map command

### DIFF
--- a/src/main/java/bout2p1_ograines/chunksloader/ChunksLoaderPlugin.java
+++ b/src/main/java/bout2p1_ograines/chunksloader/ChunksLoaderPlugin.java
@@ -220,6 +220,10 @@ public class ChunksLoaderPlugin extends JavaPlugin implements Listener {
         }
 
         if (args[0].equalsIgnoreCase("map")) {
+            if (!sender.hasPermission("chunksloader.use")) {
+                sender.sendMessage(ChatColor.RED + "You do not have permission.");
+                return true;
+            }
             if (!(sender instanceof Player player)) {
                 sender.sendMessage(ChatColor.RED + "This command is only available to players.");
                 return true;


### PR DESCRIPTION
## Summary
- ensure the `/chunksloader map` sub-command checks for the `chunksloader.use` permission before showing the map

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_69048e24cb2c8321911c8332a60ac1fb